### PR TITLE
Add race prediction page and components

### DIFF
--- a/.cursor/docs/pages/race-prediction.md
+++ b/.cursor/docs/pages/race-prediction.md
@@ -1,0 +1,65 @@
+# Race Prediction
+
+In this page the user will be able to see and manage its predictions.
+
+## UI Specification
+
+We will use the same color palette as the rest of the application.
+We will have a very minimalistic design, there will be no space between the sections. So the sections will be stacked one on top of the other with a divider line between them.
+
+We will have a navigation in the top to allow the user to switch between the different races and the champion predictions. And to switch between Race and Sprint race predictions (disabled if the race does not have a sprint race).
+
+This page will be available for all users. Only the predictions of the current user will be available to edit. And the user will be able to see the predictions of other users by clicking on the user name in the predictions card in the home page, or in the leaderboard page in the detailed view.
+
+We will also display some information about the race like the date, track name, if it is currently live, if it is completed, etc. Also saving some space to display the race results when the race is completed. This last thing could be a button to toggle the display of the race results or a modal with the race results. And another information for other users predictions to see who predicted what.
+
+### Race predictions form
+
+Will display the form to enter the predictions for the race.
+Each input will be a dropdown with the drivers names.
+
+#### Race predictions inputs
+
+- Pole position
+- Race winner
+- Top 10 drivers (except for the race winner)
+- Fastest lap
+- Fastest pit stop
+
+#### Sprint race predictions inputs (if the race has a sprint race)
+
+- Sprint pole position
+- Sprint race winner
+- Top 8 drivers (except for the sprint race winner)
+- Fastest lap
+
+#### Race prediction notes
+
+- We will not allow the user to predict the fastest pit stop for the sprint race.
+- We will not allow the user to predict the same driver for multiple final positions within the same race, same applies for the sprint race.
+
+### Champion predictions form
+
+Will display the form to enter the predictions for the champion.
+
+Each input will be a dropdown with the drivers names.
+
+- WDC winner
+- WCC winner
+
+This form will be available only before the start of the first race of the season.
+We will reopen this form after the summer break, but with the warning that the predictions will lost half of its points.
+
+#### Champion predictions notes
+
+- We will display a tooltip with the information about that this predictions are not editable after the start of the first race of the season. And the predictions will be lost half of its points if the user changes them after the summer break.
+
+### Common features
+
+- We will have a button to submit the predictions that change its color depending on the state of the predictions:
+  - If the predictions are not submitted yet, the button will be green.
+  - If the predictions are submitted but not scored yet, the button will be blue.
+  - If the predictions are scored, the button will be disabled.
+  - If the user is editing the predictions, the button will be yellow
+- We will have a box to display the point earned on the current race selected.
+- We will have a button to reset the predictions to the default values. This will be displayed for each race and each user.

--- a/app/race-prediction/page.tsx
+++ b/app/race-prediction/page.tsx
@@ -1,0 +1,54 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+import { RacePredictionContent } from "@/components/predictions/RacePredictionContent";
+import {
+  DRIVERS_2026,
+  RACES_2026,
+  TEAMS_2026,
+  DUMMY_FULL_PREDICTIONS,
+  DUMMY_SPRINT_PREDICTIONS,
+  DUMMY_CHAMPION_PREDICTION,
+  DUMMY_RACE_RESULTS,
+  DUMMY_SPRINT_RESULTS,
+} from "@/lib/dummy-data";
+
+export default async function RacePredictionPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const displayName =
+    user.user_metadata?.full_name || user.email?.split("@")[0] || "Driver";
+  const avatarUrl = user.user_metadata?.avatar_url;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <Navbar displayName={displayName} avatarUrl={avatarUrl} />
+
+      <main className="flex-1 px-4 py-6 sm:px-6 sm:py-8">
+        <div className="mx-auto max-w-4xl">
+          <RacePredictionContent
+            races={RACES_2026}
+            drivers={DRIVERS_2026}
+            teams={TEAMS_2026}
+            predictions={DUMMY_FULL_PREDICTIONS}
+            sprintPredictions={DUMMY_SPRINT_PREDICTIONS}
+            championPrediction={DUMMY_CHAMPION_PREDICTION}
+            raceResults={DUMMY_RACE_RESULTS}
+            sprintResults={DUMMY_SPRINT_RESULTS}
+            isOwner={true}
+          />
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/components/dashboard/PredictionsCard.tsx
+++ b/components/dashboard/PredictionsCard.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { FileText, ChevronRight, AlertCircle, CheckCircle2 } from "lucide-react";
 import type { RacePrediction } from "@/types";
 
@@ -40,10 +41,13 @@ export function PredictionsCard({ predictions }: PredictionsCardProps) {
             Predictions
           </p>
         </div>
-        <button className="flex items-center gap-0.5 text-[10px] font-medium text-muted transition-colors hover:text-f1-white">
+        <Link
+          href="/race-prediction"
+          className="flex items-center gap-0.5 text-[10px] font-medium text-muted transition-colors hover:text-f1-white"
+        >
           View all
           <ChevronRight size={12} />
-        </button>
+        </Link>
       </div>
 
       <div className="mt-3 flex-1 space-y-2">
@@ -72,9 +76,12 @@ export function PredictionsCard({ predictions }: PredictionsCardProps) {
               </div>
             )}
             {prediction.status === "pending" && (
-              <button className="mt-2 w-full rounded-md bg-f1-red/10 py-1.5 text-[10px] font-medium text-f1-red transition-colors hover:bg-f1-red/20">
+              <Link
+                href="/race-prediction"
+                className="mt-2 block w-full rounded-md bg-f1-red/10 py-1.5 text-center text-[10px] font-medium text-f1-red transition-colors hover:bg-f1-red/20"
+              >
                 Make Prediction
-              </button>
+              </Link>
             )}
           </div>
         ))}

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -1,9 +1,19 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import Image from "next/image";
-import { User, LogOut } from "lucide-react";
+import Link from "next/link";
+import {
+  User,
+  LogOut,
+  Home,
+  Trophy,
+  Medal,
+  Globe,
+  Moon,
+  Sun,
+} from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 
 interface NavbarProps {
@@ -15,6 +25,7 @@ export function Navbar({ displayName, avatarUrl }: NavbarProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -40,9 +51,15 @@ export function Navbar({ displayName, avatarUrl }: NavbarProps) {
     .toUpperCase()
     .slice(0, 2);
 
+  const navLinks = [
+    { href: "/", label: "Home", icon: <Home size={16} /> },
+    { href: "/race-prediction", label: "Predictions", icon: <Trophy size={16} /> },
+    { href: "/leaderboard", label: "Leaderboard", icon: <Medal size={16} /> },
+  ];
+
   return (
     <header className="flex items-center justify-between border-b border-border px-4 py-3 sm:px-6 sm:py-4">
-      <div className="flex items-center gap-3">
+      <Link href="/" className="flex items-center gap-3">
         <Image src="/logo.svg" alt="F1 Prediction" width={36} height={36} priority />
         <div className="hidden sm:block">
           <div className="flex items-baseline gap-2">
@@ -52,7 +69,7 @@ export function Navbar({ displayName, avatarUrl }: NavbarProps) {
             <span className="text-xs text-muted">Season 2026</span>
           </div>
         </div>
-      </div>
+      </Link>
 
       <div className="relative flex items-center gap-3" ref={menuRef}>
         <span className="text-sm text-muted">
@@ -77,17 +94,81 @@ export function Navbar({ displayName, avatarUrl }: NavbarProps) {
         </button>
 
         {isMenuOpen && (
-          <div className="absolute right-0 top-full z-50 mt-2 w-48 rounded-lg border border-border bg-card py-1 shadow-xl">
+          <div className="absolute right-0 top-full z-50 mt-2 w-52 rounded-lg border border-border bg-card py-1 shadow-xl">
+            {/* Navigation Links */}
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setIsMenuOpen(false)}
+                className={`flex w-full items-center gap-2 px-4 py-2.5 text-sm transition-colors hover:bg-card-hover ${
+                  pathname === link.href
+                    ? "font-medium text-f1-white"
+                    : "text-muted hover:text-f1-white"
+                }`}
+              >
+                {link.icon}
+                {link.label}
+              </Link>
+            ))}
+
+            <div className="my-1 border-t border-border" />
+
+            {/* Profile */}
             <button
-              onClick={() => {
-                setIsMenuOpen(false);
-              }}
+              onClick={() => setIsMenuOpen(false)}
               className="flex w-full items-center gap-2 px-4 py-2.5 text-sm text-muted transition-colors hover:bg-card-hover hover:text-f1-white"
             >
               <User size={16} />
               Profile
             </button>
+
             <div className="my-1 border-t border-border" />
+
+            {/* Language Selection (placeholder) */}
+            <div className="px-4 py-2">
+              <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted/50">
+                Language
+              </p>
+              <div className="flex rounded-lg border border-border">
+                <button
+                  className="flex flex-1 items-center justify-center gap-1 rounded-l-lg bg-card-hover px-2 py-1.5 text-[11px] font-medium text-f1-white"
+                >
+                  <Globe size={12} />
+                  EN
+                </button>
+                <button
+                  className="flex flex-1 items-center justify-center gap-1 rounded-r-lg border-l border-border px-2 py-1.5 text-[11px] font-medium text-muted"
+                >
+                  ES
+                </button>
+              </div>
+            </div>
+
+            {/* Theme Selection (placeholder) */}
+            <div className="px-4 py-2">
+              <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted/50">
+                Theme
+              </p>
+              <div className="flex rounded-lg border border-border">
+                <button
+                  className="flex flex-1 items-center justify-center gap-1 rounded-l-lg bg-card-hover px-2 py-1.5 text-[11px] font-medium text-f1-white"
+                >
+                  <Moon size={12} />
+                  Dark
+                </button>
+                <button
+                  className="flex flex-1 items-center justify-center gap-1 rounded-r-lg border-l border-border px-2 py-1.5 text-[11px] font-medium text-muted"
+                >
+                  <Sun size={12} />
+                  Light
+                </button>
+              </div>
+            </div>
+
+            <div className="my-1 border-t border-border" />
+
+            {/* Sign Out */}
             <button
               onClick={handleSignOut}
               className="flex w-full items-center gap-2 px-4 py-2.5 text-sm text-f1-red transition-colors hover:bg-card-hover"

--- a/components/leaderboard/LeaderboardContent.tsx
+++ b/components/leaderboard/LeaderboardContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import Link from "next/link";
 import {
   Medal,
   List,
@@ -261,12 +262,15 @@ function SimpleTable({
             }`}
           >
             <RankBadge rank={entry.rank} />
-            <span className={`font-medium ${isMe ? "text-f1-white" : "text-foreground"}`}>
+            <Link
+              href={`/race-prediction?user=${entry.userId}`}
+              className={`font-medium transition-colors hover:text-f1-red ${isMe ? "text-f1-white" : "text-foreground"}`}
+            >
               {entry.displayName}
               {isMe && (
                 <span className="ml-1.5 text-[10px] text-f1-red">(You)</span>
               )}
-            </span>
+            </Link>
             <span className="text-right tabular-nums text-muted">
               {entry.predictionsCount}/{5}
             </span>
@@ -330,8 +334,9 @@ function DetailedTable({
                   <RankBadge rank={entry.rank} />
                 </td>
                 <td className="sticky left-10 z-10 bg-inherit px-2 py-2.5 sm:left-12">
-                  <span
-                    className={`font-medium whitespace-nowrap ${
+                  <Link
+                    href={`/race-prediction?user=${entry.userId}`}
+                    className={`font-medium whitespace-nowrap transition-colors hover:text-f1-red ${
                       isMe ? "text-f1-white" : "text-foreground"
                     }`}
                   >
@@ -341,7 +346,7 @@ function DetailedTable({
                         (You)
                       </span>
                     )}
-                  </span>
+                  </Link>
                 </td>
                 {races.map((race) => {
                   const pts = entry.racePoints[race.meetingKey];

--- a/components/predictions/DriverSelect.tsx
+++ b/components/predictions/DriverSelect.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { ChevronDown, X } from "lucide-react";
+import type { Driver } from "@/types";
+
+interface DriverSelectProps {
+  label: string;
+  value: Driver | null;
+  drivers: Driver[];
+  disabledDrivers: Driver[];
+  onChange: (driver: Driver | null) => void;
+  disabled?: boolean;
+  position?: number;
+}
+
+export function DriverSelect({
+  label,
+  value,
+  drivers,
+  disabledDrivers,
+  onChange,
+  disabled = false,
+  position,
+}: DriverSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [openUpward, setOpenUpward] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+        setSearch("");
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const computeDirection = useCallback(() => {
+    if (!buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const dropdownHeight = 240;
+    setOpenUpward(spaceBelow < dropdownHeight && rect.top > dropdownHeight);
+  }, []);
+
+  const filtered = drivers.filter((d) => {
+    const q = search.toLowerCase();
+    return (
+      d.firstName.toLowerCase().includes(q) ||
+      d.lastName.toLowerCase().includes(q) ||
+      d.nameAcronym.toLowerCase().includes(q) ||
+      d.teamName.toLowerCase().includes(q)
+    );
+  });
+
+  const isDisabled = (driver: Driver) =>
+    disabledDrivers.some((dd) => dd.driverNumber === driver.driverNumber);
+
+  return (
+    <div ref={ref} className="relative">
+      <label className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-muted">
+        {position !== undefined && (
+          <span className="mr-1 text-[10px] tabular-nums text-muted/60">
+            P{position}
+          </span>
+        )}
+        {label}
+      </label>
+      <button
+        ref={buttonRef}
+        type="button"
+        disabled={disabled}
+        onClick={() => {
+          if (!open) {
+            computeDirection();
+            setOpen(true);
+            setTimeout(() => inputRef.current?.focus(), 50);
+          } else {
+            setOpen(false);
+            setSearch("");
+          }
+        }}
+        className={`flex w-full items-center justify-between rounded-lg border px-3 py-2 text-xs transition-colors ${
+          disabled
+            ? "cursor-not-allowed border-border bg-card/50 text-muted/50"
+            : open
+              ? "border-border-hover bg-input-bg text-f1-white"
+              : "border-border bg-input-bg text-foreground hover:border-border-hover"
+        }`}
+      >
+        {value ? (
+          <span className="flex items-center gap-2">
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: `#${value.teamColor}` }}
+            />
+            <span className="font-medium">{value.nameAcronym}</span>
+            <span className="text-muted">
+              {value.firstName} {value.lastName}
+            </span>
+          </span>
+        ) : (
+          <span className="text-muted">Select driver...</span>
+        )}
+        <div className="flex items-center gap-1">
+          {value && !disabled && (
+            <span
+              role="button"
+              tabIndex={-1}
+              onClick={(e) => {
+                e.stopPropagation();
+                onChange(null);
+              }}
+              className="rounded p-0.5 text-muted hover:text-f1-white"
+            >
+              <X size={12} />
+            </span>
+          )}
+          <ChevronDown
+            size={14}
+            className={`text-muted transition-transform ${open ? "rotate-180" : ""}`}
+          />
+        </div>
+      </button>
+
+      {open && !disabled && (
+        <div
+          className={`absolute left-0 z-40 w-full rounded-lg border border-border bg-card shadow-xl ${
+            openUpward ? "bottom-full mb-1" : "top-full mt-1"
+          }`}
+        >
+          <div className="border-b border-border p-2">
+            <input
+              ref={inputRef}
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search driver..."
+              className="w-full rounded-md bg-input-bg px-2.5 py-1.5 text-xs text-f1-white placeholder:text-muted/50 focus:outline-none"
+            />
+          </div>
+          <div className="max-h-48 overflow-y-auto py-1">
+            {filtered.length === 0 ? (
+              <p className="px-3 py-2 text-xs text-muted">No drivers found</p>
+            ) : (
+              filtered.map((driver) => {
+                const isSelected =
+                  value?.driverNumber === driver.driverNumber;
+                const isUnavailable = isDisabled(driver);
+                return (
+                  <button
+                    key={driver.driverNumber}
+                    type="button"
+                    disabled={isUnavailable}
+                    onClick={() => {
+                      onChange(driver);
+                      setOpen(false);
+                      setSearch("");
+                    }}
+                    className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors ${
+                      isSelected
+                        ? "bg-f1-red/10 text-f1-white"
+                        : isUnavailable
+                          ? "cursor-not-allowed text-muted/30"
+                          : "text-foreground hover:bg-card-hover"
+                    }`}
+                  >
+                    <span
+                      className="h-2 w-2 shrink-0 rounded-full"
+                      style={{
+                        backgroundColor: `#${driver.teamColor}`,
+                        opacity: isUnavailable ? 0.3 : 1,
+                      }}
+                    />
+                    <span className="font-medium">{driver.nameAcronym}</span>
+                    <span className={isUnavailable ? "text-muted/30" : "text-muted"}>
+                      {driver.firstName} {driver.lastName}
+                    </span>
+                    <span
+                      className={`ml-auto text-[10px] ${isUnavailable ? "text-muted/20" : "text-muted/50"}`}
+                    >
+                      {driver.teamName}
+                    </span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/predictions/RacePredictionContent.tsx
+++ b/components/predictions/RacePredictionContent.tsx
@@ -1,0 +1,927 @@
+"use client";
+
+import { useState, useMemo, useCallback, useRef } from "react";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Trophy,
+  Zap,
+  Flag,
+  Clock,
+  CheckCircle2,
+  Circle,
+  Send,
+  RotateCcw,
+  Info,
+  Eye,
+  EyeOff,
+  Crown,
+} from "lucide-react";
+import type {
+  Race,
+  Driver,
+  FullRacePrediction,
+  SprintPrediction,
+  ChampionPrediction,
+  RaceResult,
+  SprintResult,
+  RaceStatus,
+} from "@/types";
+import { getRaceStatus } from "@/lib/dummy-data";
+import { DriverSelect } from "./DriverSelect";
+
+type TabMode = "race" | "sprint" | "champion";
+
+interface RacePredictionContentProps {
+  races: Race[];
+  drivers: Driver[];
+  teams: string[];
+  predictions: FullRacePrediction[];
+  sprintPredictions: SprintPrediction[];
+  championPrediction: ChampionPrediction;
+  raceResults: Record<number, RaceResult>;
+  sprintResults: Record<number, SprintResult>;
+  isOwner: boolean;
+  initialRaceIndex?: number;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const config: Record<string, { bg: string; text: string; label: string }> = {
+    pending: { bg: "bg-f1-amber/15", text: "text-f1-amber", label: "Pending" },
+    submitted: { bg: "bg-f1-blue/15", text: "text-f1-blue", label: "Submitted" },
+    scored: { bg: "bg-f1-green/15", text: "text-f1-green", label: "Scored" },
+  };
+  const c = config[status] ?? config.pending;
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${c.bg} ${c.text}`}>
+      {status === "scored" ? <CheckCircle2 size={10} /> : <Circle size={10} />}
+      {c.label}
+    </span>
+  );
+}
+
+function RaceStatusBadge({ status }: { status: RaceStatus }) {
+  const config: Record<RaceStatus, { bg: string; text: string; label: string; icon: React.ReactNode }> = {
+    upcoming: { bg: "bg-f1-blue/15", text: "text-f1-blue", label: "Upcoming", icon: <Clock size={10} /> },
+    live: { bg: "bg-f1-red/15", text: "text-f1-red", label: "LIVE", icon: <Zap size={10} /> },
+    completed: { bg: "bg-f1-green/15", text: "text-f1-green", label: "Completed", icon: <CheckCircle2 size={10} /> },
+  };
+  const c = config[status];
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${c.bg} ${c.text}`}>
+      {c.icon}
+      {c.label}
+    </span>
+  );
+}
+
+export function RacePredictionContent({
+  races,
+  drivers,
+  teams,
+  predictions: initialPredictions,
+  sprintPredictions: initialSprintPredictions,
+  championPrediction: initialChampionPrediction,
+  raceResults,
+  sprintResults,
+  isOwner,
+  initialRaceIndex = 0,
+}: RacePredictionContentProps) {
+  const [raceIndex, setRaceIndex] = useState(initialRaceIndex);
+  const [tab, setTab] = useState<TabMode>("race");
+  const [predictions, setPredictions] = useState(initialPredictions);
+  const [sprintPreds, setSprintPreds] = useState(initialSprintPredictions);
+  const [champPred, setChampPred] = useState(initialChampionPrediction);
+  const [showResults, setShowResults] = useState(false);
+
+  const currentRace = races[raceIndex];
+  const raceStatus = getRaceStatus(currentRace);
+  const isChampionTab = tab === "champion";
+
+  const currentPrediction = predictions.find((p) => p.raceId === currentRace.meetingKey);
+  const currentSprintPred = sprintPreds.find((p) => p.raceId === currentRace.meetingKey);
+  const currentResult = raceResults[currentRace.meetingKey];
+  const currentSprintResult = sprintResults[currentRace.meetingKey];
+
+  const isEditable = isOwner && (
+    isChampionTab
+      ? champPred.status !== "scored"
+      : tab === "sprint"
+        ? currentSprintPred?.status !== "scored"
+        : currentPrediction?.status !== "scored"
+  );
+
+  const hasEdits = useMemo(() => {
+    if (isChampionTab) return champPred.wdcWinner !== null || champPred.wccWinner !== null;
+    if (tab === "sprint" && currentSprintPred) {
+      return currentSprintPred.sprintPole !== null || currentSprintPred.sprintWinner !== null || currentSprintPred.restOfTop8.some((d) => d !== null);
+    }
+    if (currentPrediction) {
+      return currentPrediction.polePosition !== null || currentPrediction.raceWinner !== null || currentPrediction.restOfTop10.some((d) => d !== null);
+    }
+    return false;
+  }, [isChampionTab, tab, champPred, currentSprintPred, currentPrediction]);
+
+  const getSubmitButtonConfig = useCallback(() => {
+    const status = isChampionTab
+      ? champPred.status
+      : tab === "sprint"
+        ? currentSprintPred?.status ?? "pending"
+        : currentPrediction?.status ?? "pending";
+
+    if (status === "scored") return { color: "bg-muted/20 text-muted cursor-not-allowed", label: "Scored" };
+    if (status === "submitted" && !hasEdits) return { color: "bg-f1-blue text-white", label: "Submitted" };
+    if (status === "submitted") return { color: "bg-f1-amber text-black", label: "Update Prediction" };
+    return { color: "bg-f1-green text-black hover:bg-f1-green/80", label: "Submit Prediction" };
+  }, [isChampionTab, tab, champPred, currentSprintPred, currentPrediction, hasEdits]);
+
+  const submitConfig = getSubmitButtonConfig();
+
+  const usedDriversInRace = useMemo(() => {
+    if (!currentPrediction) return [];
+    const used: Driver[] = [];
+    if (currentPrediction.raceWinner) used.push(currentPrediction.raceWinner);
+    currentPrediction.restOfTop10.forEach((d) => { if (d) used.push(d); });
+    return used;
+  }, [currentPrediction]);
+
+  const usedDriversInSprint = useMemo(() => {
+    if (!currentSprintPred) return [];
+    const used: Driver[] = [];
+    if (currentSprintPred.sprintWinner) used.push(currentSprintPred.sprintWinner);
+    currentSprintPred.restOfTop8.forEach((d) => { if (d) used.push(d); });
+    return used;
+  }, [currentSprintPred]);
+
+  const getDisabledForPosition = useCallback(
+    (posIndex: number, mode: "race" | "sprint") => {
+      if (mode === "race" && currentPrediction) {
+        const used: Driver[] = [];
+        if (currentPrediction.raceWinner) used.push(currentPrediction.raceWinner);
+        currentPrediction.restOfTop10.forEach((d, i) => {
+          if (d && i !== posIndex) used.push(d);
+        });
+        return used;
+      }
+      if (mode === "sprint" && currentSprintPred) {
+        const used: Driver[] = [];
+        if (currentSprintPred.sprintWinner) used.push(currentSprintPred.sprintWinner);
+        currentSprintPred.restOfTop8.forEach((d, i) => {
+          if (d && i !== posIndex) used.push(d);
+        });
+        return used;
+      }
+      return [];
+    },
+    [currentPrediction, currentSprintPred]
+  );
+
+  const getDisabledForWinner = useCallback(
+    (mode: "race" | "sprint") => {
+      if (mode === "race" && currentPrediction) {
+        return currentPrediction.restOfTop10.filter((d): d is Driver => d !== null);
+      }
+      if (mode === "sprint" && currentSprintPred) {
+        return currentSprintPred.restOfTop8.filter((d): d is Driver => d !== null);
+      }
+      return [];
+    },
+    [currentPrediction, currentSprintPred]
+  );
+
+  function updateRacePrediction(update: Partial<FullRacePrediction>) {
+    setPredictions((prev) =>
+      prev.map((p) =>
+        p.raceId === currentRace.meetingKey ? { ...p, ...update } : p
+      )
+    );
+  }
+
+  function updateSprintPrediction(update: Partial<SprintPrediction>) {
+    setSprintPreds((prev) =>
+      prev.map((p) =>
+        p.raceId === currentRace.meetingKey ? { ...p, ...update } : p
+      )
+    );
+  }
+
+  function handleReset() {
+    if (isChampionTab) {
+      setChampPred({ ...champPred, wdcWinner: null, wccWinner: null, status: "pending" });
+    } else if (tab === "sprint") {
+      updateSprintPrediction({
+        sprintPole: null,
+        sprintWinner: null,
+        restOfTop8: [null, null, null, null, null, null, null],
+        fastestLap: null,
+        status: "pending",
+      });
+    } else {
+      updateRacePrediction({
+        polePosition: null,
+        raceWinner: null,
+        restOfTop10: [null, null, null, null, null, null, null, null, null],
+        fastestLap: null,
+        fastestPitStop: null,
+        status: "pending",
+      });
+    }
+  }
+
+  function handleSubmit() {
+    if (isChampionTab) {
+      setChampPred({ ...champPred, status: "submitted" });
+    } else if (tab === "sprint") {
+      updateSprintPrediction({ status: "submitted" });
+    } else {
+      updateRacePrediction({ status: "submitted" });
+    }
+  }
+
+  const pointsEarned = isChampionTab
+    ? champPred.pointsEarned
+    : tab === "sprint"
+      ? currentSprintPred?.pointsEarned ?? null
+      : currentPrediction?.pointsEarned ?? null;
+
+  const teamColors = useMemo(() => {
+    const map: Record<string, string> = {};
+    drivers.forEach((d) => {
+      if (!map[d.teamName]) map[d.teamName] = d.teamColor;
+    });
+    return map;
+  }, [drivers]);
+
+  const formatDate = (dateStr: string) => {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  };
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-border">
+      {/* Race Navigation */}
+      <div className="flex items-center justify-between border-b border-border px-4 py-3 sm:px-5">
+        <button
+          disabled={raceIndex === 0 && !isChampionTab}
+          onClick={() => {
+            if (isChampionTab) {
+              setTab("race");
+              setRaceIndex(races.length - 1);
+            } else if (raceIndex > 0) {
+              setRaceIndex(raceIndex - 1);
+              setTab("race");
+            }
+          }}
+          className="flex h-7 w-7 items-center justify-center rounded-md border border-border text-muted transition-colors hover:border-border-hover hover:text-f1-white disabled:opacity-30"
+        >
+          <ChevronLeft size={14} />
+        </button>
+
+        <div className="flex flex-wrap items-center justify-center gap-1.5 sm:gap-2">
+          {races.map((race, i) => (
+            <button
+              key={race.meetingKey}
+              onClick={() => {
+                setRaceIndex(i);
+                if (tab === "champion") setTab("race");
+                if (tab === "sprint" && !race.hasSprint) setTab("race");
+              }}
+              className={`rounded-md px-2 py-1 text-[10px] font-medium transition-colors sm:px-2.5 ${
+                !isChampionTab && raceIndex === i
+                  ? "bg-f1-red text-white"
+                  : "text-muted hover:bg-card-hover hover:text-f1-white"
+              }`}
+            >
+              <span className="hidden sm:inline">R{race.round}</span>
+              <span className="sm:hidden">{race.round}</span>
+            </button>
+          ))}
+          <button
+            onClick={() => setTab("champion")}
+            className={`flex items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium transition-colors sm:px-2.5 ${
+              isChampionTab
+                ? "bg-f1-amber text-black"
+                : "text-muted hover:bg-card-hover hover:text-f1-white"
+            }`}
+          >
+            <Crown size={10} />
+            <span className="hidden sm:inline">Champion</span>
+          </button>
+        </div>
+
+        <button
+          disabled={isChampionTab}
+          onClick={() => {
+            if (raceIndex < races.length - 1) {
+              setRaceIndex(raceIndex + 1);
+              setTab("race");
+            } else {
+              setTab("champion");
+            }
+          }}
+          className="flex h-7 w-7 items-center justify-center rounded-md border border-border text-muted transition-colors hover:border-border-hover hover:text-f1-white disabled:opacity-30"
+        >
+          <ChevronRight size={14} />
+        </button>
+      </div>
+
+      {/* Race Info / Champion Header */}
+      {isChampionTab ? (
+        <ChampionHeader />
+      ) : (
+        <RaceInfoBar
+          race={currentRace}
+          raceStatus={raceStatus}
+          formatDate={formatDate}
+          pointsEarned={pointsEarned}
+        />
+      )}
+
+      {/* Race/Sprint Toggle (only for race tabs with sprint) */}
+      {!isChampionTab && (
+        <div className="flex border-b border-border">
+          <button
+            onClick={() => setTab("race")}
+            className={`flex flex-1 items-center justify-center gap-1.5 py-2.5 text-[11px] font-medium transition-colors ${
+              tab === "race"
+                ? "border-b-2 border-f1-red text-f1-white"
+                : "text-muted hover:text-f1-white"
+            }`}
+          >
+            <Flag size={12} />
+            Race
+          </button>
+          <button
+            onClick={() => currentRace.hasSprint && setTab("sprint")}
+            disabled={!currentRace.hasSprint}
+            className={`flex flex-1 items-center justify-center gap-1.5 py-2.5 text-[11px] font-medium transition-colors ${
+              tab === "sprint"
+                ? "border-b-2 border-f1-red text-f1-white"
+                : !currentRace.hasSprint
+                  ? "cursor-not-allowed text-muted/30"
+                  : "text-muted hover:text-f1-white"
+            }`}
+          >
+            <Zap size={12} />
+            Sprint
+            {!currentRace.hasSprint && (
+              <span className="text-[9px] text-muted/30">N/A</span>
+            )}
+          </button>
+        </div>
+      )}
+
+      {/* Results Toggle */}
+      {!isChampionTab && raceStatus === "completed" && (
+        <div className="border-b border-border px-4 py-2 sm:px-5">
+          <button
+            onClick={() => setShowResults(!showResults)}
+            className="flex items-center gap-1.5 text-[11px] font-medium text-f1-blue transition-colors hover:text-f1-blue/80"
+          >
+            {showResults ? <EyeOff size={12} /> : <Eye size={12} />}
+            {showResults ? "Hide Results" : "Show Results"}
+          </button>
+        </div>
+      )}
+
+      {/* Results Display */}
+      {showResults && !isChampionTab && tab === "race" && currentResult && (
+        <ResultsDisplay result={currentResult} type="race" />
+      )}
+      {showResults && !isChampionTab && tab === "sprint" && currentSprintResult && (
+        <SprintResultsDisplay result={currentSprintResult} />
+      )}
+
+      {/* Prediction Form */}
+      <div className="px-4 py-4 sm:px-5 sm:py-5">
+        {isChampionTab ? (
+          <ChampionForm
+            prediction={champPred}
+            drivers={drivers}
+            teams={teams}
+            teamColors={teamColors}
+            isEditable={isEditable}
+            onChange={setChampPred}
+          />
+        ) : tab === "sprint" ? (
+          currentSprintPred ? (
+            <SprintForm
+              prediction={currentSprintPred}
+              drivers={drivers}
+              isEditable={isEditable}
+              getDisabledForPosition={(i) => getDisabledForPosition(i, "sprint")}
+              getDisabledForWinner={() => getDisabledForWinner("sprint")}
+              onChange={(update) => updateSprintPrediction(update)}
+            />
+          ) : (
+            <p className="py-8 text-center text-xs text-muted">
+              No sprint predictions available for this race.
+            </p>
+          )
+        ) : currentPrediction ? (
+          <RaceForm
+            prediction={currentPrediction}
+            drivers={drivers}
+            isEditable={isEditable}
+            getDisabledForPosition={(i) => getDisabledForPosition(i, "race")}
+            getDisabledForWinner={() => getDisabledForWinner("race")}
+            onChange={(update) => updateRacePrediction(update)}
+          />
+        ) : (
+          <p className="py-8 text-center text-xs text-muted">
+            No predictions available for this race.
+          </p>
+        )}
+      </div>
+
+      {/* Points & Actions Bar */}
+      <div className="flex items-center justify-between border-t border-border px-4 py-3 sm:px-5">
+        <div className="flex items-center gap-3">
+          {pointsEarned !== null && (
+            <div className="flex items-center gap-1.5">
+              <Trophy size={14} className="text-f1-amber" />
+              <span className="text-sm font-bold tabular-nums text-f1-amber">
+                {pointsEarned}
+              </span>
+              <span className="text-[10px] text-muted">pts earned</span>
+            </div>
+          )}
+          <StatusBadge
+            status={
+              isChampionTab
+                ? champPred.status
+                : tab === "sprint"
+                  ? currentSprintPred?.status ?? "pending"
+                  : currentPrediction?.status ?? "pending"
+            }
+          />
+        </div>
+
+        {isOwner && (
+          <div className="flex items-center gap-2">
+            {isEditable && (
+              <button
+                onClick={handleReset}
+                className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-[11px] font-medium text-muted transition-colors hover:border-border-hover hover:text-f1-white"
+              >
+                <RotateCcw size={12} />
+                Reset
+              </button>
+            )}
+            <button
+              onClick={handleSubmit}
+              disabled={!isEditable}
+              className={`flex items-center gap-1.5 rounded-lg px-4 py-1.5 text-[11px] font-semibold transition-colors ${submitConfig.color}`}
+            >
+              <Send size={12} />
+              {submitConfig.label}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ---------- Race Info Bar ---------- */
+
+function RaceInfoBar({
+  race,
+  raceStatus,
+  formatDate,
+  pointsEarned,
+}: {
+  race: Race;
+  raceStatus: RaceStatus;
+  formatDate: (d: string) => string;
+  pointsEarned: number | null;
+}) {
+  return (
+    <div className="flex flex-col gap-2 border-b border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-5">
+      <div className="flex items-center gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold text-f1-white">
+              {race.raceName}
+            </h2>
+            <RaceStatusBadge status={raceStatus} />
+          </div>
+          <p className="mt-0.5 text-[11px] text-muted">
+            {race.circuitShortName} — {race.location}, {race.countryName}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="text-[11px] tabular-nums text-muted">
+          {formatDate(race.dateStart)} – {formatDate(race.dateEnd)}
+        </span>
+        <span className="rounded-full bg-card px-2 py-0.5 text-[10px] font-medium tabular-nums text-muted">
+          R{race.round}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ---------- Champion Header ---------- */
+
+function ChampionHeader() {
+  return (
+    <div className="flex items-center justify-between border-b border-border px-4 py-3 sm:px-5">
+      <div className="flex items-center gap-2">
+        <Crown size={16} className="text-f1-amber" />
+        <h2 className="text-sm font-semibold text-f1-white">
+          Championship Predictions
+        </h2>
+      </div>
+      <div className="group relative">
+        <Info size={14} className="cursor-help text-muted" />
+        <div className="pointer-events-none absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border border-border bg-card p-3 opacity-0 shadow-xl transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">
+          <p className="text-[11px] leading-relaxed text-muted">
+            Championship predictions are locked after the start of the first race.
+            Predictions changed after the summer break earn half points.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ---------- Race Form ---------- */
+
+function RaceForm({
+  prediction,
+  drivers,
+  isEditable,
+  getDisabledForPosition,
+  getDisabledForWinner,
+  onChange,
+}: {
+  prediction: FullRacePrediction;
+  drivers: Driver[];
+  isEditable: boolean;
+  getDisabledForPosition: (i: number) => Driver[];
+  getDisabledForWinner: () => Driver[];
+  onChange: (update: Partial<FullRacePrediction>) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <DriverSelect
+          label="Pole Position"
+          value={prediction.polePosition}
+          drivers={drivers}
+          disabledDrivers={[]}
+          onChange={(d) => onChange({ polePosition: d })}
+          disabled={!isEditable}
+        />
+        <DriverSelect
+          label="Race Winner (P1)"
+          value={prediction.raceWinner}
+          drivers={drivers}
+          disabledDrivers={getDisabledForWinner()}
+          onChange={(d) => onChange({ raceWinner: d })}
+          disabled={!isEditable}
+        />
+      </div>
+
+      <div>
+        <div className="mb-2 flex items-center gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+            Rest of Top 10
+          </span>
+          <span className="text-[9px] text-muted/50">(P2 – P10, excluding race winner)</span>
+        </div>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {prediction.restOfTop10.map((driver, i) => (
+            <DriverSelect
+              key={i}
+              label=""
+              position={i + 2}
+              value={driver}
+              drivers={drivers}
+              disabledDrivers={getDisabledForPosition(i)}
+              onChange={(d) => {
+                const updated = [...prediction.restOfTop10];
+                updated[i] = d;
+                onChange({ restOfTop10: updated });
+              }}
+              disabled={!isEditable}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <DriverSelect
+          label="Fastest Lap"
+          value={prediction.fastestLap}
+          drivers={drivers}
+          disabledDrivers={[]}
+          onChange={(d) => onChange({ fastestLap: d })}
+          disabled={!isEditable}
+        />
+        <DriverSelect
+          label="Fastest Pit Stop"
+          value={prediction.fastestPitStop}
+          drivers={drivers}
+          disabledDrivers={[]}
+          onChange={(d) => onChange({ fastestPitStop: d })}
+          disabled={!isEditable}
+        />
+      </div>
+    </div>
+  );
+}
+
+/* ---------- Sprint Form ---------- */
+
+function SprintForm({
+  prediction,
+  drivers,
+  isEditable,
+  getDisabledForPosition,
+  getDisabledForWinner,
+  onChange,
+}: {
+  prediction: SprintPrediction;
+  drivers: Driver[];
+  isEditable: boolean;
+  getDisabledForPosition: (i: number) => Driver[];
+  getDisabledForWinner: () => Driver[];
+  onChange: (update: Partial<SprintPrediction>) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <DriverSelect
+          label="Sprint Pole Position"
+          value={prediction.sprintPole}
+          drivers={drivers}
+          disabledDrivers={[]}
+          onChange={(d) => onChange({ sprintPole: d })}
+          disabled={!isEditable}
+        />
+        <DriverSelect
+          label="Sprint Winner (P1)"
+          value={prediction.sprintWinner}
+          drivers={drivers}
+          disabledDrivers={getDisabledForWinner()}
+          onChange={(d) => onChange({ sprintWinner: d })}
+          disabled={!isEditable}
+        />
+      </div>
+
+      <div>
+        <div className="mb-2 flex items-center gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+            Rest of Top 8
+          </span>
+          <span className="text-[9px] text-muted/50">(P2 – P8, excluding sprint winner)</span>
+        </div>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {prediction.restOfTop8.map((driver, i) => (
+            <DriverSelect
+              key={i}
+              label=""
+              position={i + 2}
+              value={driver}
+              drivers={drivers}
+              disabledDrivers={getDisabledForPosition(i)}
+              onChange={(d) => {
+                const updated = [...prediction.restOfTop8];
+                updated[i] = d;
+                onChange({ restOfTop8: updated });
+              }}
+              disabled={!isEditable}
+            />
+          ))}
+        </div>
+      </div>
+
+      <DriverSelect
+        label="Fastest Lap"
+        value={prediction.fastestLap}
+        drivers={drivers}
+        disabledDrivers={[]}
+        onChange={(d) => onChange({ fastestLap: d })}
+        disabled={!isEditable}
+      />
+    </div>
+  );
+}
+
+/* ---------- Champion Form ---------- */
+
+function ChampionForm({
+  prediction,
+  drivers,
+  teams,
+  teamColors,
+  isEditable,
+  onChange,
+}: {
+  prediction: ChampionPrediction;
+  drivers: Driver[];
+  teams: string[];
+  teamColors: Record<string, string>;
+  isEditable: boolean;
+  onChange: (pred: ChampionPrediction) => void;
+}) {
+  const [teamOpen, setTeamOpen] = useState(false);
+  const [openUpward, setOpenUpward] = useState(false);
+  const teamBtnRef = useRef<HTMLButtonElement>(null);
+
+  function handleTeamToggle() {
+    if (!teamOpen && teamBtnRef.current) {
+      const rect = teamBtnRef.current.getBoundingClientRect();
+      const spaceBelow = window.innerHeight - rect.bottom;
+      setOpenUpward(spaceBelow < 240 && rect.top > 240);
+    }
+    setTeamOpen(!teamOpen);
+  }
+
+  return (
+    <div className="space-y-4">
+      {prediction.isHalfPoints && (
+        <div className="flex items-center gap-2 rounded-lg border border-f1-amber/30 bg-f1-amber/5 px-3 py-2">
+          <Info size={14} className="shrink-0 text-f1-amber" />
+          <p className="text-[11px] text-f1-amber">
+            Predictions changed after the summer break earn half points.
+          </p>
+        </div>
+      )}
+
+      <DriverSelect
+        label="World Drivers' Champion (WDC)"
+        value={prediction.wdcWinner}
+        drivers={drivers}
+        disabledDrivers={[]}
+        onChange={(d) => onChange({ ...prediction, wdcWinner: d })}
+        disabled={!isEditable}
+      />
+
+      <div className="relative">
+        <label className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-muted">
+          World Constructors&apos; Champion (WCC)
+        </label>
+        <button
+          ref={teamBtnRef}
+          type="button"
+          disabled={!isEditable}
+          onClick={handleTeamToggle}
+          className={`flex w-full items-center justify-between rounded-lg border px-3 py-2 text-xs transition-colors ${
+            !isEditable
+              ? "cursor-not-allowed border-border bg-card/50 text-muted/50"
+              : teamOpen
+                ? "border-border-hover bg-input-bg text-f1-white"
+                : "border-border bg-input-bg text-foreground hover:border-border-hover"
+          }`}
+        >
+          {prediction.wccWinner ? (
+            <span className="flex items-center gap-2 font-medium">
+              <span
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: `#${teamColors[prediction.wccWinner] ?? "737373"}` }}
+              />
+              {prediction.wccWinner}
+            </span>
+          ) : (
+            <span className="text-muted">Select team...</span>
+          )}
+          <ChevronDown size={14} className={`text-muted transition-transform ${teamOpen ? "rotate-180" : ""}`} />
+        </button>
+        {teamOpen && isEditable && (
+          <div
+            className={`absolute left-0 z-40 w-full rounded-lg border border-border bg-card py-1 shadow-xl ${
+              openUpward ? "bottom-full mb-1" : "top-full mt-1"
+            }`}
+          >
+            <div className="max-h-48 overflow-y-auto">
+              {teams.map((team) => (
+                <button
+                  key={team}
+                  type="button"
+                  onClick={() => {
+                    onChange({ ...prediction, wccWinner: team });
+                    setTeamOpen(false);
+                  }}
+                  className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors hover:bg-card-hover ${
+                    prediction.wccWinner === team
+                      ? "font-medium text-f1-white"
+                      : "text-foreground"
+                  }`}
+                >
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: `#${teamColors[team] ?? "737373"}` }}
+                  />
+                  {team}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ---------- Results Display ---------- */
+
+function ResultsDisplay({
+  result,
+}: {
+  result: RaceResult;
+  type: "race";
+}) {
+  return (
+    <div className="border-b border-border bg-card/30 px-4 py-3 sm:px-5">
+      <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-f1-green">
+        Race Results
+      </h3>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs sm:grid-cols-4">
+        <ResultItem label="Pole" driver={result.polePosition} />
+        <ResultItem label="Winner" driver={result.raceWinner} />
+        <ResultItem label="Fastest Lap" driver={result.fastestLap} />
+        <ResultItem label="Fastest Pit" driver={result.fastestPitStop} />
+      </div>
+      <div className="mt-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+          Top 10
+        </span>
+        <div className="mt-1 flex flex-wrap gap-1.5">
+          {result.top10.map((driver, i) => (
+            <span
+              key={driver.driverNumber}
+              className="inline-flex items-center gap-1 rounded-md bg-card px-2 py-0.5 text-[10px]"
+            >
+              <span className="tabular-nums text-muted">{i + 1}.</span>
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ backgroundColor: `#${driver.teamColor}` }}
+              />
+              <span className="font-medium text-foreground">
+                {driver.nameAcronym}
+              </span>
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SprintResultsDisplay({ result }: { result: SprintResult }) {
+  return (
+    <div className="border-b border-border bg-card/30 px-4 py-3 sm:px-5">
+      <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-f1-green">
+        Sprint Results
+      </h3>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs sm:grid-cols-3">
+        <ResultItem label="Sprint Pole" driver={result.sprintPole} />
+        <ResultItem label="Sprint Winner" driver={result.sprintWinner} />
+        <ResultItem label="Fastest Lap" driver={result.fastestLap} />
+      </div>
+      <div className="mt-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+          Top 8
+        </span>
+        <div className="mt-1 flex flex-wrap gap-1.5">
+          {result.top8.map((driver, i) => (
+            <span
+              key={driver.driverNumber}
+              className="inline-flex items-center gap-1 rounded-md bg-card px-2 py-0.5 text-[10px]"
+            >
+              <span className="tabular-nums text-muted">{i + 1}.</span>
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ backgroundColor: `#${driver.teamColor}` }}
+              />
+              <span className="font-medium text-foreground">
+                {driver.nameAcronym}
+              </span>
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ResultItem({ label, driver }: { label: string; driver: Driver }) {
+  return (
+    <div>
+      <span className="text-[10px] text-muted">{label}</span>
+      <div className="flex items-center gap-1.5">
+        <span
+          className="h-2 w-2 rounded-full"
+          style={{ backgroundColor: `#${driver.teamColor}` }}
+        />
+        <span className="font-medium text-foreground">{driver.nameAcronym}</span>
+        <span className="text-muted">{driver.lastName}</span>
+      </div>
+    </div>
+  );
+}

--- a/lib/dummy-data.ts
+++ b/lib/dummy-data.ts
@@ -6,29 +6,37 @@ import type {
   UserStats,
   RacePrediction,
   PointSystemSection,
+  FullRacePrediction,
+  SprintPrediction,
+  ChampionPrediction,
+  RaceResult,
+  SprintResult,
 } from "@/types";
 
 export const DRIVERS_2026: Driver[] = [
-  { driverNumber: 1, firstName: "Max", lastName: "Verstappen", nameAcronym: "VER", teamName: "Red Bull Racing", teamColor: "3671C6" },
-  { driverNumber: 4, firstName: "Lando", lastName: "Norris", nameAcronym: "NOR", teamName: "McLaren", teamColor: "FF8000" },
-  { driverNumber: 16, firstName: "Charles", lastName: "Leclerc", nameAcronym: "LEC", teamName: "Ferrari", teamColor: "E8002D" },
+  // Ordered by 2025 WDC standings
+  { driverNumber: 1, firstName: "Lando", lastName: "Norris", nameAcronym: "NOR", teamName: "McLaren", teamColor: "FF8000" },
+  { driverNumber: 3, firstName: "Max", lastName: "Verstappen", nameAcronym: "VER", teamName: "Red Bull Racing", teamColor: "3671C6" },
   { driverNumber: 81, firstName: "Oscar", lastName: "Piastri", nameAcronym: "PIA", teamName: "McLaren", teamColor: "FF8000" },
-  { driverNumber: 44, firstName: "Lewis", lastName: "Hamilton", nameAcronym: "HAM", teamName: "Ferrari", teamColor: "E8002D" },
   { driverNumber: 63, firstName: "George", lastName: "Russell", nameAcronym: "RUS", teamName: "Mercedes", teamColor: "27F4D2" },
-  { driverNumber: 14, firstName: "Fernando", lastName: "Alonso", nameAcronym: "ALO", teamName: "Aston Martin", teamColor: "229971" },
-  { driverNumber: 55, firstName: "Carlos", lastName: "Sainz", nameAcronym: "SAI", teamName: "Williams", teamColor: "1868DB" },
-  { driverNumber: 11, firstName: "Sergio", lastName: "Perez", nameAcronym: "PER", teamName: "Red Bull Racing", teamColor: "3671C6" },
+  { driverNumber: 16, firstName: "Charles", lastName: "Leclerc", nameAcronym: "LEC", teamName: "Ferrari", teamColor: "E8002D" },
+  { driverNumber: 44, firstName: "Lewis", lastName: "Hamilton", nameAcronym: "HAM", teamName: "Ferrari", teamColor: "E8002D" },
+  { driverNumber: 12, firstName: "Kimi", lastName: "Antonelli", nameAcronym: "ANT", teamName: "Mercedes", teamColor: "27F4D2" },
   { driverNumber: 23, firstName: "Alexander", lastName: "Albon", nameAcronym: "ALB", teamName: "Williams", teamColor: "1868DB" },
+  { driverNumber: 55, firstName: "Carlos", lastName: "Sainz", nameAcronym: "SAI", teamName: "Williams", teamColor: "1868DB" },
+  { driverNumber: 14, firstName: "Fernando", lastName: "Alonso", nameAcronym: "ALO", teamName: "Aston Martin", teamColor: "229971" },
+  { driverNumber: 27, firstName: "Nico", lastName: "Hulkenberg", nameAcronym: "HUL", teamName: "Audi", teamColor: "E0002B" },
+  { driverNumber: 6, firstName: "Isack", lastName: "Hadjar", nameAcronym: "HAD", teamName: "Red Bull Racing", teamColor: "3671C6" },
+  { driverNumber: 87, firstName: "Oliver", lastName: "Bearman", nameAcronym: "BEA", teamName: "Haas", teamColor: "B6BABD" },
+  { driverNumber: 30, firstName: "Liam", lastName: "Lawson", nameAcronym: "LAW", teamName: "Racing Bulls", teamColor: "6692FF" },
+  { driverNumber: 31, firstName: "Esteban", lastName: "Ocon", nameAcronym: "OCO", teamName: "Haas", teamColor: "B6BABD" },
   { driverNumber: 18, firstName: "Lance", lastName: "Stroll", nameAcronym: "STR", teamName: "Aston Martin", teamColor: "229971" },
   { driverNumber: 10, firstName: "Pierre", lastName: "Gasly", nameAcronym: "GAS", teamName: "Alpine", teamColor: "0093CC" },
-  { driverNumber: 31, firstName: "Esteban", lastName: "Ocon", nameAcronym: "OCO", teamName: "Haas", teamColor: "B6BABD" },
-  { driverNumber: 22, firstName: "Yuki", lastName: "Tsunoda", nameAcronym: "TSU", teamName: "Racing Bulls", teamColor: "6692FF" },
-  { driverNumber: 27, firstName: "Nico", lastName: "Hulkenberg", nameAcronym: "HUL", teamName: "Sauber", teamColor: "52E252" },
-  { driverNumber: 87, firstName: "Oliver", lastName: "Bearman", nameAcronym: "BEA", teamName: "Haas", teamColor: "B6BABD" },
-  { driverNumber: 12, firstName: "Andrea", lastName: "Kimi Antonelli", nameAcronym: "ANT", teamName: "Mercedes", teamColor: "27F4D2" },
+  { driverNumber: 5, firstName: "Gabriel", lastName: "Bortoleto", nameAcronym: "BOR", teamName: "Audi", teamColor: "E0002B" },
   { driverNumber: 43, firstName: "Franco", lastName: "Colapinto", nameAcronym: "COL", teamName: "Alpine", teamColor: "0093CC" },
-  { driverNumber: 30, firstName: "Liam", lastName: "Lawson", nameAcronym: "LAW", teamName: "Racing Bulls", teamColor: "6692FF" },
-  { driverNumber: 5, firstName: "Gabriel", lastName: "Bortoleto", nameAcronym: "BOR", teamName: "Sauber", teamColor: "52E252" },
+  { driverNumber: 11, firstName: "Sergio", lastName: "Perez", nameAcronym: "PER", teamName: "Cadillac", teamColor: "1E1E1E" },
+  { driverNumber: 77, firstName: "Valtteri", lastName: "Bottas", nameAcronym: "BOT", teamName: "Cadillac", teamColor: "1E1E1E" },
+  { driverNumber: 41, firstName: "Arvid", lastName: "Lindblad", nameAcronym: "LIN", teamName: "Racing Bulls", teamColor: "6692FF" },
 ];
 
 export const RACES_2026: Race[] = [
@@ -165,6 +173,125 @@ export const POINT_SYSTEM: PointSystemSection[] = [
     maxPoints: 40,
   },
 ];
+
+export const TEAMS_2026 = [
+  // Ordered by 2025 WCC standings + new entry
+  "McLaren",
+  "Mercedes",
+  "Red Bull Racing",
+  "Ferrari",
+  "Williams",
+  "Racing Bulls",
+  "Aston Martin",
+  "Haas",
+  "Audi",
+  "Alpine",
+  "Cadillac",
+];
+
+const d = (acronym: string) =>
+  DRIVERS_2026.find((dr) => dr.nameAcronym === acronym)!;
+
+export const DUMMY_RACE_RESULTS: Record<number, RaceResult> = {
+  1280: {
+    raceId: 1280,
+    polePosition: d("VER"),
+    raceWinner: d("VER"),
+    top10: [d("VER"), d("NOR"), d("LEC"), d("PIA"), d("HAM"), d("RUS"), d("ALO"), d("SAI"), d("PER"), d("ALB")],
+    fastestLap: d("NOR"),
+    fastestPitStop: d("RUS"),
+  },
+};
+
+export const DUMMY_SPRINT_RESULTS: Record<number, SprintResult> = {
+  1281: {
+    raceId: 1281,
+    sprintPole: d("NOR"),
+    sprintWinner: d("NOR"),
+    top8: [d("NOR"), d("VER"), d("LEC"), d("PIA"), d("HAM"), d("RUS"), d("SAI"), d("ALO")],
+    fastestLap: d("VER"),
+  },
+};
+
+export const DUMMY_FULL_PREDICTIONS: FullRacePrediction[] = [
+  {
+    raceId: 1280,
+    userId: "current",
+    status: "scored",
+    polePosition: d("VER"),
+    raceWinner: d("VER"),
+    restOfTop10: [d("LEC"), d("NOR"), d("PIA"), d("HAM"), d("RUS"), d("ALO"), d("PER"), d("SAI"), d("ALB")],
+    fastestLap: d("VER"),
+    fastestPitStop: d("HAM"),
+    pointsEarned: 32,
+  },
+  {
+    raceId: 1281,
+    userId: "current",
+    status: "submitted",
+    polePosition: d("NOR"),
+    raceWinner: d("NOR"),
+    restOfTop10: [d("VER"), d("LEC"), d("PIA"), d("RUS"), d("HAM"), d("SAI"), d("ALO"), d("PER"), d("GAS")],
+    fastestLap: d("NOR"),
+    fastestPitStop: d("PIA"),
+    pointsEarned: null,
+  },
+  {
+    raceId: 1282,
+    userId: "current",
+    status: "pending",
+    polePosition: null,
+    raceWinner: null,
+    restOfTop10: [null, null, null, null, null, null, null, null, null],
+    fastestLap: null,
+    fastestPitStop: null,
+    pointsEarned: null,
+  },
+  {
+    raceId: 1283,
+    userId: "current",
+    status: "pending",
+    polePosition: null,
+    raceWinner: null,
+    restOfTop10: [null, null, null, null, null, null, null, null, null],
+    fastestLap: null,
+    fastestPitStop: null,
+    pointsEarned: null,
+  },
+  {
+    raceId: 1284,
+    userId: "current",
+    status: "pending",
+    polePosition: null,
+    raceWinner: null,
+    restOfTop10: [null, null, null, null, null, null, null, null, null],
+    fastestLap: null,
+    fastestPitStop: null,
+    pointsEarned: null,
+  },
+];
+
+export const DUMMY_SPRINT_PREDICTIONS: SprintPrediction[] = [
+  {
+    raceId: 1281,
+    userId: "current",
+    status: "submitted",
+    sprintPole: d("NOR"),
+    sprintWinner: d("VER"),
+    restOfTop8: [d("NOR"), d("LEC"), d("PIA"), d("HAM"), d("RUS"), d("SAI"), d("ALO")],
+    fastestLap: d("NOR"),
+    pointsEarned: null,
+  },
+];
+
+export const DUMMY_CHAMPION_PREDICTION: ChampionPrediction = {
+  userId: "current",
+  status: "submitted",
+  wdcWinner: d("VER"),
+  wccWinner: "McLaren",
+  pointsEarned: null,
+  isHalfPoints: false,
+};
 
 export function getNextRace(): Race | undefined {
   const now = new Date();

--- a/types/index.ts
+++ b/types/index.ts
@@ -24,17 +24,70 @@ export interface Race {
 
 export type RaceStatus = "upcoming" | "live" | "completed";
 
+export type PredictionStatus = "pending" | "submitted" | "scored";
+
 export interface RacePrediction {
   raceId: number;
   raceName: string;
   round: number;
-  status: "pending" | "submitted" | "scored";
+  status: PredictionStatus;
   top10: Driver[];
   fastestLap?: Driver;
   polePosition?: Driver;
   fastestPitStop?: Driver;
   pointsEarned?: number;
   maxPoints: number;
+}
+
+export interface FullRacePrediction {
+  raceId: number;
+  userId: string;
+  status: PredictionStatus;
+  polePosition: Driver | null;
+  raceWinner: Driver | null;
+  /** P2 through P10 (9 slots, excluding the race winner who is P1) */
+  restOfTop10: (Driver | null)[];
+  fastestLap: Driver | null;
+  fastestPitStop: Driver | null;
+  pointsEarned: number | null;
+}
+
+export interface SprintPrediction {
+  raceId: number;
+  userId: string;
+  status: PredictionStatus;
+  sprintPole: Driver | null;
+  sprintWinner: Driver | null;
+  /** P2 through P8 (7 slots, excluding the sprint winner who is P1) */
+  restOfTop8: (Driver | null)[];
+  fastestLap: Driver | null;
+  pointsEarned: number | null;
+}
+
+export interface ChampionPrediction {
+  userId: string;
+  status: PredictionStatus;
+  wdcWinner: Driver | null;
+  wccWinner: string | null;
+  pointsEarned: number | null;
+  isHalfPoints: boolean;
+}
+
+export interface RaceResult {
+  raceId: number;
+  polePosition: Driver;
+  raceWinner: Driver;
+  top10: Driver[];
+  fastestLap: Driver;
+  fastestPitStop: Driver;
+}
+
+export interface SprintResult {
+  raceId: number;
+  sprintPole: Driver;
+  sprintWinner: Driver;
+  top8: Driver[];
+  fastestLap: Driver;
 }
 
 export interface LeaderboardEntry {


### PR DESCRIPTION
This pull request introduces a new race prediction page and enhances navigation and user experience throughout the application. The main changes are the addition of the race prediction UI and page, improved navigation in the navbar, and better linking between dashboard, leaderboard, and prediction pages. The pull request also adds a custom driver selection component for predictions.

**Race Prediction Features and UI:**

* Added a new `.cursor/docs/pages/race-prediction.md` documentation page describing the race prediction UI, its minimalistic design, navigation, forms for race and champion predictions, and common features such as submission and reset buttons.
* Created `app/race-prediction/page.tsx` for the race prediction page, including authentication checks and rendering of the `RacePredictionContent` with dummy data.
* Introduced a new `DriverSelect` component for selecting drivers in prediction forms, supporting search, disabled drivers, and improved dropdown UX.

**Navigation and Linking Improvements:**

* Enhanced the `Navbar` component with new navigation links (Home, Predictions, Leaderboard), visual highlighting for the current page, and placeholders for language and theme selection. [[1]](diffhunk://#diff-de0112ec022fc8f19641573c73093fea805f0e7584306236fc275c478e35c067L4-R16) [[2]](diffhunk://#diff-de0112ec022fc8f19641573c73093fea805f0e7584306236fc275c478e35c067R28) [[3]](diffhunk://#diff-de0112ec022fc8f19641573c73093fea805f0e7584306236fc275c478e35c067R54-R62) [[4]](diffhunk://#diff-de0112ec022fc8f19641573c73093fea805f0e7584306236fc275c478e35c067L55-R72) [[5]](diffhunk://#diff-de0112ec022fc8f19641573c73093fea805f0e7584306236fc275c478e35c067L80-R171)
* Updated `PredictionsCard` in the dashboard to use `Link` components for "View all" and "Make Prediction" actions, directing users to the race prediction page. [[1]](diffhunk://#diff-de98fd8c57e4230233e8cba2c2d3d2e6fb96c4f273c707111b080f2b9543517bR1) [[2]](diffhunk://#diff-de98fd8c57e4230233e8cba2c2d3d2e6fb96c4f273c707111b080f2b9543517bL43-R50) [[3]](diffhunk://#diff-de98fd8c57e4230233e8cba2c2d3d2e6fb96c4f273c707111b080f2b9543517bL75-R84)
* Modified leaderboard tables to link user display names to their race prediction pages, allowing detailed views of other users' predictions. [[1]](diffhunk://#diff-7680bcc312b5480e51a5879effcbd197574d86a9e1110c9518da2569e40c13ebR4) [[2]](diffhunk://#diff-7680bcc312b5480e51a5879effcbd197574d86a9e1110c9518da2569e40c13ebL264-R273) [[3]](diffhunk://#diff-7680bcc312b5480e51a5879effcbd197574d86a9e1110c9518da2569e40c13ebL333-R339) [[4]](diffhunk://#diff-7680bcc312b5480e51a5879effcbd197574d86a9e1110c9518da2569e40c13ebL344-R349)