### PR TITLE
feat: mobile race prediction screen (Phase 3, race tab)

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -4,3 +4,9 @@
 # Find them in the Supabase dashboard under Settings -> API.
 EXPO_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+
+# Base URL of the shared Next.js backend (the app/api routes).
+# Dev: the LAN URL of the machine running `npm run dev`, reachable from the
+# phone (e.g. http://192.168.1.x:3000 — localhost on the device is NOT the
+# dev machine). Production: the deployed web app URL.
+EXPO_PUBLIC_API_URL=http://192.168.1.x:3000

--- a/apps/mobile/src/app/(app)/index.tsx
+++ b/apps/mobile/src/app/(app)/index.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "expo-router";
 import { useState } from "react";
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
 import { fetchRaces } from "@f1/shared/lib/races";
@@ -40,6 +41,22 @@ export default function HomeScreen() {
         <Text className="text-3xl font-bold text-f1-white">F1 Prediction</Text>
         <Text className="text-f1-red font-semibold">{t.navbar.season}</Text>
       </View>
+
+      <Link href="/race-prediction" asChild>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t.nav.predictions}
+          className="flex-row items-center justify-between rounded-2xl bg-f1-red p-5 active:bg-f1-red-hover"
+        >
+          <View className="gap-0.5">
+            <Text className="text-lg font-bold text-white">{t.nav.predictions}</Text>
+            {nextRace ? (
+              <Text className="text-xs text-white/80">{nextRace.raceName}</Text>
+            ) : null}
+          </View>
+          <Text className="text-2xl text-white">›</Text>
+        </Pressable>
+      </Link>
 
       <View className="rounded-2xl bg-f1-white/5 border border-f1-white/10 p-4 gap-2">
         <Text className="text-f1-purple font-semibold">{t.navbar.signedInAs}</Text>

--- a/apps/mobile/src/app/(app)/race-prediction.tsx
+++ b/apps/mobile/src/app/(app)/race-prediction.tsx
@@ -1,0 +1,661 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Stack } from "expo-router";
+import { useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { fetchDrivers } from "@f1/shared/lib/drivers";
+import { fetchUserRacePredictions } from "@f1/shared/lib/predictions";
+import { fetchRaces } from "@f1/shared/lib/races";
+import { countryCodeToFlag, getRaceStatus } from "@f1/shared/lib/race-utils";
+import type { Driver, FullRacePrediction } from "@f1/shared/types";
+
+import { ConfirmModal } from "@/components/predictions/ConfirmModal";
+import { CountdownBar } from "@/components/predictions/CountdownBar";
+import { DriverPickerModal } from "@/components/predictions/DriverPickerModal";
+import { DriverSlot } from "@/components/predictions/DriverSlot";
+import { RoundSelectorModal } from "@/components/predictions/RoundSelectorModal";
+import { PredictionStatusBadge, RaceStatusBadge } from "@/components/predictions/StatusBadges";
+import { apiFetch } from "@/lib/api";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/providers/AuthProvider";
+import { useLanguage } from "@/providers/LanguageProvider";
+
+/** Which prediction slot the driver picker is currently editing. */
+type SlotTarget =
+  | { kind: "qualifying"; index: number }
+  | { kind: "winner" }
+  | { kind: "rest"; index: number }
+  | { kind: "fastestLap" }
+  | { kind: "fastestPitStop" }
+  | { kind: "driverOfTheDay" };
+
+export default function RacePredictionScreen() {
+  const { t, language } = useLanguage();
+  const { user } = useAuth();
+  const userId = user?.id;
+  const queryClient = useQueryClient();
+
+  /* ── Data ─────────────────────────────────────────────────────────── */
+
+  const racesQuery = useQuery({
+    queryKey: ["races"],
+    queryFn: () => fetchRaces(supabase),
+  });
+  const driversQuery = useQuery({
+    queryKey: ["drivers"],
+    queryFn: () => fetchDrivers(supabase),
+  });
+  const races = useMemo(
+    () => [...(racesQuery.data ?? [])].sort((a, b) => a.round - b.round),
+    [racesQuery.data]
+  );
+  const predictionsQuery = useQuery({
+    queryKey: ["racePredictions", userId],
+    queryFn: () => fetchUserRacePredictions(supabase, userId!, races),
+    enabled: !!userId && races.length > 0,
+  });
+
+  /* ── Local edit state (mirrors the web: edits live locally until submit) ── */
+
+  const [predictions, setPredictions] = useState<FullRacePrediction[] | null>(null);
+  useEffect(() => {
+    if (predictionsQuery.data) setPredictions(predictionsQuery.data);
+  }, [predictionsQuery.data]);
+
+  /* ── Round selection (default: first race whose weekend hasn't ended) ── */
+
+  const defaultRaceIndex = useMemo(() => {
+    const now = Date.now();
+    const idx = races.findIndex((race) => new Date(race.dateEnd).getTime() > now);
+    return idx === -1 ? Math.max(0, races.length - 1) : idx;
+  }, [races]);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const raceIndex = selectedIndex ?? defaultRaceIndex;
+
+  const [roundPickerOpen, setRoundPickerOpen] = useState(false);
+  const [pickerTarget, setPickerTarget] = useState<SlotTarget | null>(null);
+  const [showResetModal, setShowResetModal] = useState(false);
+  const [showSubmitModal, setShowSubmitModal] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // Deadlines that expired while the screen was open (countdown hit zero).
+  const [expiredMeetingKeys, setExpiredMeetingKeys] = useState<Set<number>>(new Set());
+
+  /* ── Loading / error states ───────────────────────────────────────── */
+
+  const isPending =
+    racesQuery.isPending || driversQuery.isPending || predictionsQuery.isPending || !predictions;
+  const loadError = racesQuery.error ?? driversQuery.error ?? predictionsQuery.error;
+
+  if (loadError) {
+    return (
+      <ScreenShell title={t.nav.predictions}>
+        <View className="flex-1 items-center justify-center gap-4 p-6">
+          <Text className="text-center text-sm text-f1-white/70">
+            {t.predictionsPage.loadError}
+          </Text>
+          <Pressable
+            onPress={() => {
+              racesQuery.refetch();
+              driversQuery.refetch();
+              predictionsQuery.refetch();
+            }}
+            accessibilityRole="button"
+            accessibilityLabel={t.predictionsPage.retry}
+            className="min-h-11 items-center justify-center rounded-lg bg-f1-red px-6 active:bg-f1-red-hover"
+          >
+            <Text className="font-semibold text-white">{t.predictionsPage.retry}</Text>
+          </Pressable>
+        </View>
+      </ScreenShell>
+    );
+  }
+
+  if (isPending || races.length === 0) {
+    return (
+      <ScreenShell title={t.nav.predictions}>
+        <View className="flex-1 items-center justify-center p-6">
+          {isPending ? (
+            <ActivityIndicator color="#CF2637" />
+          ) : (
+            <Text className="text-sm text-f1-white/50">{t.predictionsPage.noPredictions}</Text>
+          )}
+        </View>
+      </ScreenShell>
+    );
+  }
+
+  /* ── Derived state for the selected round ─────────────────────────── */
+
+  const currentRace = races[Math.min(raceIndex, races.length - 1)];
+  const raceStatus = getRaceStatus(currentRace);
+  const drivers = driversQuery.data ?? [];
+  const currentPrediction =
+    (predictions ?? []).find((p) => p.raceId === currentRace.meetingKey) ?? null;
+
+  const deadlinePassed =
+    new Date(currentRace.dateEnd).getTime() <= Date.now() ||
+    expiredMeetingKeys.has(currentRace.meetingKey);
+  const isEditable = currentPrediction?.status !== "scored" && !deadlinePassed;
+
+  const hasEdits =
+    !!currentPrediction &&
+    (currentPrediction.qualifyingTop3.some((d) => d !== null) ||
+      currentPrediction.raceWinner !== null ||
+      currentPrediction.restOfTop10.some((d) => d !== null));
+
+  const formatDate = (dateStr: string) =>
+    new Date(dateStr).toLocaleDateString(language === "es" ? "es-ES" : "en-US", {
+      month: "short",
+      day: "numeric",
+    });
+
+  /* ── Slot helpers (shared driver pool for winner + rest of top 10) ── */
+
+  function getSlotLabel(slot: SlotTarget): string {
+    switch (slot.kind) {
+      case "qualifying":
+        return `Q${slot.index + 1}`;
+      case "winner":
+        return t.predictionsPage.raceWinner;
+      case "rest":
+        return `P${slot.index + 2}`;
+      case "fastestLap":
+        return t.predictionsPage.fastestLap;
+      case "fastestPitStop":
+        return t.predictionsPage.fastestPitStop;
+      case "driverOfTheDay":
+        return t.predictionsPage.driverOfTheDay;
+    }
+  }
+
+  function getSlotValue(pred: FullRacePrediction, slot: SlotTarget): Driver | null {
+    switch (slot.kind) {
+      case "qualifying":
+        return pred.qualifyingTop3[slot.index];
+      case "winner":
+        return pred.raceWinner;
+      case "rest":
+        return pred.restOfTop10[slot.index];
+      case "fastestLap":
+        return pred.fastestLap;
+      case "fastestPitStop":
+        return pred.fastestPitStop;
+      case "driverOfTheDay":
+        return pred.driverOfTheDay;
+    }
+  }
+
+  function getDisabledForSlot(pred: FullRacePrediction, slot: SlotTarget): Driver[] {
+    if (slot.kind === "qualifying") {
+      return pred.qualifyingTop3.filter(
+        (d, i): d is Driver => d !== null && i !== slot.index
+      );
+    }
+    if (slot.kind === "winner") {
+      return pred.restOfTop10.filter((d): d is Driver => d !== null);
+    }
+    if (slot.kind === "rest") {
+      const used: Driver[] = [];
+      if (pred.raceWinner) used.push(pred.raceWinner);
+      pred.restOfTop10.forEach((d, i) => {
+        if (d && i !== slot.index) used.push(d);
+      });
+      return used;
+    }
+    return []; // specials may repeat drivers freely
+  }
+
+  function updateCurrentPrediction(update: Partial<FullRacePrediction>) {
+    setPredictions((prev) =>
+      prev
+        ? prev.map((p) => (p.raceId === currentRace.meetingKey ? { ...p, ...update } : p))
+        : prev
+    );
+  }
+
+  function applySlot(slot: SlotTarget, driver: Driver | null) {
+    if (!currentPrediction) return;
+    switch (slot.kind) {
+      case "qualifying": {
+        const updated = [...currentPrediction.qualifyingTop3];
+        updated[slot.index] = driver;
+        updateCurrentPrediction({ qualifyingTop3: updated });
+        break;
+      }
+      case "winner":
+        updateCurrentPrediction({ raceWinner: driver });
+        break;
+      case "rest": {
+        const updated = [...currentPrediction.restOfTop10];
+        updated[slot.index] = driver;
+        updateCurrentPrediction({ restOfTop10: updated });
+        break;
+      }
+      case "fastestLap":
+        updateCurrentPrediction({ fastestLap: driver });
+        break;
+      case "fastestPitStop":
+        updateCurrentPrediction({ fastestPitStop: driver });
+        break;
+      case "driverOfTheDay":
+        updateCurrentPrediction({ driverOfTheDay: driver });
+        break;
+    }
+  }
+
+  /* ── Submit / reset ───────────────────────────────────────────────── */
+
+  async function invalidatePredictions() {
+    await queryClient.invalidateQueries({ queryKey: ["racePredictions", userId] });
+  }
+
+  async function handleSubmit() {
+    if (!currentPrediction || isSaving) return;
+    setIsSaving(true);
+    setErrorMessage(null);
+    try {
+      const payload = {
+        type: "race",
+        raceId: currentRace.meetingKey,
+        qualifyingTop3: currentPrediction.qualifyingTop3.map((d) => d?.driverNumber ?? null),
+        top10: [
+          currentPrediction.raceWinner?.driverNumber ?? null,
+          ...currentPrediction.restOfTop10.map((d) => d?.driverNumber ?? null),
+        ],
+        fastestLapDriverNumber: currentPrediction.fastestLap?.driverNumber ?? null,
+        fastestPitStopDriverNumber: currentPrediction.fastestPitStop?.driverNumber ?? null,
+        driverOfTheDayDriverNumber: currentPrediction.driverOfTheDay?.driverNumber ?? null,
+      };
+      const res = await apiFetch("/api/predictions/submit", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}) as { error?: string });
+        setErrorMessage(data?.error || t.predictionsPage.submitError);
+        return;
+      }
+      updateCurrentPrediction({ status: "submitted" });
+      await invalidatePredictions();
+    } catch {
+      setErrorMessage(t.predictionsPage.submitError);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleReset() {
+    if (isSaving) return;
+    setIsSaving(true);
+    setErrorMessage(null);
+    try {
+      const res = await apiFetch("/api/predictions/reset", {
+        method: "POST",
+        body: JSON.stringify({ type: "race", raceId: currentRace.meetingKey }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}) as { error?: string });
+        setErrorMessage(data?.error || t.predictionsPage.resetError);
+        return;
+      }
+      updateCurrentPrediction({
+        qualifyingTop3: [null, null, null],
+        raceWinner: null,
+        restOfTop10: Array.from({ length: 9 }, () => null),
+        fastestLap: null,
+        fastestPitStop: null,
+        driverOfTheDay: null,
+        status: "pending",
+      });
+      await invalidatePredictions();
+    } catch {
+      setErrorMessage(t.predictionsPage.resetError);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleRefresh() {
+    setRefreshing(true);
+    try {
+      await Promise.all([
+        racesQuery.refetch(),
+        driversQuery.refetch(),
+        predictionsQuery.refetch(),
+      ]);
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  /* ── Submit button config (mirrors the web status → color mapping) ── */
+
+  const status = currentPrediction?.status ?? "pending";
+  const submitConfig =
+    status === "scored"
+      ? { className: "bg-f1-white/10", textClassName: "text-f1-white/40", label: t.predictionsPage.scored, disabled: true }
+      : status === "submitted" && !hasEdits
+        ? { className: "bg-f1-blue active:bg-f1-blue/80", textClassName: "text-white", label: t.predictionsPage.submitted, disabled: false }
+        : status === "submitted"
+          ? { className: "bg-f1-amber active:bg-f1-amber/80", textClassName: "text-black", label: t.predictionsPage.updatePrediction, disabled: false }
+          : { className: "bg-f1-green active:bg-f1-green/80", textClassName: "text-black", label: t.predictionsPage.submitPrediction, disabled: false };
+
+  const pickerValue =
+    pickerTarget && currentPrediction ? getSlotValue(currentPrediction, pickerTarget) : null;
+
+  return (
+    <ScreenShell title={t.nav.predictions}>
+      <ScrollView
+        className="flex-1"
+        contentContainerClassName="p-4 gap-4 pb-8"
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor="#CF2637" />
+        }
+      >
+        {/* ── Round selector ── */}
+        <View className="flex-row items-center gap-2">
+          <Pressable
+            onPress={() => setSelectedIndex(Math.max(0, raceIndex - 1))}
+            disabled={raceIndex === 0}
+            accessibilityRole="button"
+            accessibilityLabel={t.predictionsPage.previousRound}
+            className={`h-11 w-11 items-center justify-center rounded-xl border border-f1-white/10 active:bg-f1-white/10 ${
+              raceIndex === 0 ? "opacity-30" : ""
+            }`}
+          >
+            <Ionicons name="chevron-back" size={18} color="#F7F7F7" />
+          </Pressable>
+
+          <Pressable
+            onPress={() => setRoundPickerOpen(true)}
+            accessibilityRole="button"
+            accessibilityLabel={`${t.predictionsPage.roundSelectorLabel}: R${currentRace.round} ${currentRace.raceName}`}
+            className="min-h-11 flex-1 flex-row items-center gap-2 rounded-xl border border-f1-white/10 bg-f1-white/5 px-3 py-2 active:bg-f1-white/10"
+          >
+            <Text className="text-base">{countryCodeToFlag(currentRace.countryCode)}</Text>
+            <View className="flex-1">
+              <Text className="text-xs font-bold tabular-nums text-f1-white/50">
+                R{String(currentRace.round).padStart(2, "0")}
+              </Text>
+              <Text className="text-sm font-semibold text-f1-white" numberOfLines={1}>
+                {currentRace.raceName}
+              </Text>
+              <Text className="text-xs text-f1-white/50">
+                {formatDate(currentRace.dateStart)} – {formatDate(currentRace.dateEnd)}
+              </Text>
+            </View>
+            <Ionicons name="chevron-down" size={16} color="#F7F7F766" />
+          </Pressable>
+
+          <Pressable
+            onPress={() => setSelectedIndex(Math.min(races.length - 1, raceIndex + 1))}
+            disabled={raceIndex === races.length - 1}
+            accessibilityRole="button"
+            accessibilityLabel={t.predictionsPage.nextRound}
+            className={`h-11 w-11 items-center justify-center rounded-xl border border-f1-white/10 active:bg-f1-white/10 ${
+              raceIndex === races.length - 1 ? "opacity-30" : ""
+            }`}
+          >
+            <Ionicons name="chevron-forward" size={18} color="#F7F7F7" />
+          </Pressable>
+        </View>
+
+        {/* ── Status row: race badge + countdown / closed banner ── */}
+        <View className="gap-2">
+          <View className="flex-row items-center gap-2">
+            <RaceStatusBadge status={raceStatus} />
+            <PredictionStatusBadge status={status} />
+          </View>
+          {!deadlinePassed ? (
+            <CountdownBar
+              deadline={currentRace.dateEnd}
+              onExpire={() =>
+                setExpiredMeetingKeys((prev) => new Set(prev).add(currentRace.meetingKey))
+              }
+            />
+          ) : (
+            <View className="flex-row items-center gap-2 rounded-lg border border-f1-red/30 bg-f1-red/10 px-3 py-2">
+              <Ionicons name="time-outline" size={14} color="#CF2637" />
+              <Text className="text-xs font-semibold text-f1-red">
+                {t.predictionsPage.predictionsClosed}
+              </Text>
+            </View>
+          )}
+        </View>
+
+        {/* ── Form ── */}
+        {currentPrediction ? (
+          <View className="gap-5">
+            {/* Qualifying top 3 */}
+            <View className="gap-2">
+              <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-white/60">
+                {t.predictionsPage.qualifyingTop3}
+              </Text>
+              {currentPrediction.qualifyingTop3.map((driver, i) => (
+                <DriverSlot
+                  key={`q-${i}`}
+                  label={`Q${i + 1}`}
+                  value={driver}
+                  disabled={!isEditable}
+                  onPress={() => setPickerTarget({ kind: "qualifying", index: i })}
+                />
+              ))}
+            </View>
+
+            {/* Race winner */}
+            <DriverSlot
+              label={t.predictionsPage.raceWinner}
+              value={currentPrediction.raceWinner}
+              disabled={!isEditable}
+              onPress={() => setPickerTarget({ kind: "winner" })}
+            />
+
+            {/* Rest of top 10 */}
+            <View className="gap-2">
+              <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-white/60">
+                {t.predictionsPage.restOfTop10}
+              </Text>
+              {currentPrediction.restOfTop10.map((driver, i) => (
+                <DriverSlot
+                  key={`p-${i}`}
+                  label=""
+                  position={i + 2}
+                  value={driver}
+                  disabled={!isEditable}
+                  onPress={() => setPickerTarget({ kind: "rest", index: i })}
+                />
+              ))}
+            </View>
+
+            {/* Specials */}
+            <View className="gap-2">
+              <DriverSlot
+                label={t.predictionsPage.fastestLap}
+                value={currentPrediction.fastestLap}
+                disabled={!isEditable}
+                onPress={() => setPickerTarget({ kind: "fastestLap" })}
+              />
+              <DriverSlot
+                label={t.predictionsPage.fastestPitStop}
+                value={currentPrediction.fastestPitStop}
+                disabled={!isEditable}
+                onPress={() => setPickerTarget({ kind: "fastestPitStop" })}
+              />
+              <DriverSlot
+                label={t.predictionsPage.driverOfTheDay}
+                value={currentPrediction.driverOfTheDay}
+                disabled={!isEditable}
+                onPress={() => setPickerTarget({ kind: "driverOfTheDay" })}
+              />
+            </View>
+          </View>
+        ) : (
+          <Text className="py-8 text-center text-sm text-f1-white/50">
+            {t.predictionsPage.noPredictions}
+          </Text>
+        )}
+
+        {/* ── Error banner ── */}
+        {errorMessage && (
+          <View className="flex-row items-center gap-2 rounded-lg border border-f1-red/30 bg-f1-red/10 px-3 py-2.5">
+            <Text className="flex-1 text-xs font-medium text-f1-red">{errorMessage}</Text>
+            <Pressable
+              onPress={() => setErrorMessage(null)}
+              accessibilityRole="button"
+              accessibilityLabel={t.predictionsPage.dismiss}
+              className="min-h-8 justify-center px-2"
+            >
+              <Text className="text-xs text-f1-red/70">{t.predictionsPage.dismiss}</Text>
+            </Pressable>
+          </View>
+        )}
+
+        {/* ── Points + actions bar ── */}
+        <View className="flex-row items-center justify-between border-t border-f1-white/10 pt-4">
+          <View className="flex-row items-center gap-2">
+            {currentPrediction?.pointsEarned !== null &&
+              currentPrediction?.pointsEarned !== undefined && (
+                <View className="flex-row items-center gap-1.5">
+                  <Ionicons name="trophy" size={16} color="#FFB100" />
+                  <Text className="text-base font-bold tabular-nums text-f1-amber">
+                    {currentPrediction.pointsEarned}
+                  </Text>
+                  <Text className="text-xs text-f1-white/50">{t.predictionsPage.ptsEarned}</Text>
+                </View>
+              )}
+          </View>
+
+          <View className="flex-row items-center gap-2">
+            {isEditable && (
+              <Pressable
+                onPress={() => setShowResetModal(true)}
+                disabled={isSaving}
+                accessibilityRole="button"
+                accessibilityLabel={t.predictionsPage.reset}
+                className={`min-h-11 flex-row items-center gap-1.5 rounded-lg border border-f1-white/10 px-4 active:bg-f1-white/10 ${
+                  isSaving ? "opacity-50" : ""
+                }`}
+              >
+                <Ionicons name="refresh" size={14} color="#F7F7F7AA" />
+                <Text className="text-sm font-medium text-f1-white/70">
+                  {t.predictionsPage.reset}
+                </Text>
+              </Pressable>
+            )}
+            {deadlinePassed ? (
+              <View className="min-h-11 flex-row items-center gap-1.5 rounded-lg bg-f1-red/15 px-4">
+                <Ionicons name="time-outline" size={14} color="#CF2637" />
+                <Text className="text-sm font-semibold text-f1-red">
+                  {t.predictionsPage.deadlinePassed}
+                </Text>
+              </View>
+            ) : (
+              <Pressable
+                onPress={() => {
+                  if (status === "submitted") {
+                    setShowSubmitModal(true);
+                  } else {
+                    handleSubmit();
+                  }
+                }}
+                disabled={!isEditable || isSaving || submitConfig.disabled}
+                accessibilityRole="button"
+                accessibilityLabel={submitConfig.label}
+                accessibilityState={{ disabled: !isEditable || isSaving || submitConfig.disabled }}
+                className={`min-h-11 flex-row items-center gap-2 rounded-lg px-5 ${submitConfig.className} ${
+                  isSaving || !isEditable ? "opacity-70" : ""
+                }`}
+              >
+                {isSaving ? <ActivityIndicator size="small" color="#2A2B2A" /> : null}
+                <Text className={`text-sm font-semibold ${submitConfig.textClassName}`}>
+                  {isSaving ? t.predictionsPage.saving : submitConfig.label}
+                </Text>
+              </Pressable>
+            )}
+          </View>
+        </View>
+      </ScrollView>
+
+      {/* ── Modals ── */}
+      <RoundSelectorModal
+        visible={roundPickerOpen}
+        races={races}
+        selectedIndex={raceIndex}
+        onSelect={(i) => {
+          setSelectedIndex(i);
+          setRoundPickerOpen(false);
+        }}
+        onClose={() => setRoundPickerOpen(false)}
+      />
+
+      <DriverPickerModal
+        visible={pickerTarget !== null}
+        label={pickerTarget ? getSlotLabel(pickerTarget) : ""}
+        drivers={drivers}
+        value={pickerValue}
+        disabledDrivers={
+          pickerTarget && currentPrediction
+            ? getDisabledForSlot(currentPrediction, pickerTarget)
+            : []
+        }
+        onSelect={(driver) => {
+          if (pickerTarget) applySlot(pickerTarget, driver);
+          setPickerTarget(null);
+        }}
+        onClose={() => setPickerTarget(null)}
+      />
+
+      <ConfirmModal
+        visible={showResetModal}
+        title={t.predictionsPage.resetPrediction}
+        subtitle={currentRace.raceName}
+        body={`${t.predictionsPage.resetBody} ${t.predictionsPage.resetBodyPending}${t.predictionsPage.resetBodySuffix}`}
+        confirmLabel={t.predictionsPage.resetConfirm}
+        confirmingLabel={t.predictionsPage.resetting}
+        tone="red"
+        isSaving={isSaving}
+        onConfirm={() => {
+          setShowResetModal(false);
+          handleReset();
+        }}
+        onCancel={() => setShowResetModal(false)}
+      />
+
+      <ConfirmModal
+        visible={showSubmitModal}
+        title={t.predictionsPage.updateConfirmTitle}
+        subtitle={currentRace.raceName}
+        body={t.predictionsPage.updateConfirmBody}
+        confirmLabel={t.predictionsPage.confirmUpdate}
+        confirmingLabel={t.predictionsPage.updating}
+        tone="blue"
+        isSaving={isSaving}
+        onConfirm={() => {
+          setShowSubmitModal(false);
+          handleSubmit();
+        }}
+        onCancel={() => setShowSubmitModal(false)}
+      />
+    </ScreenShell>
+  );
+}
+
+/** Shared wrapper: sets the native header title and the dark background. */
+function ScreenShell({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <View className="flex-1 bg-f1-black">
+      <Stack.Screen options={{ title }} />
+      {children}
+    </View>
+  );
+}

--- a/apps/mobile/src/app/auth/callback.tsx
+++ b/apps/mobile/src/app/auth/callback.tsx
@@ -1,0 +1,35 @@
+import { useRouter } from "expo-router";
+import { useEffect } from "react";
+import { ActivityIndicator, View } from "react-native";
+
+import { useAuth } from "@/providers/AuthProvider";
+
+/**
+ * Landing screen for the OAuth deep link (exp://.../--/auth/callback or
+ * f1prediction://auth/callback). On some Android browsers the redirect
+ * arrives as a plain link, so Expo Router navigates here while the root
+ * layout's useURL() handler exchanges the ?code= for a session. Show a
+ * spinner until that lands, then forward home — Stack.Protected resolves
+ * "/" to the app when signed in or back to the login screen if the
+ * exchange failed (10s safety timeout).
+ */
+export default function AuthCallbackScreen() {
+  const { session, isLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (session) {
+      router.replace("/");
+      return;
+    }
+    const timeout = setTimeout(() => router.replace("/"), 10_000);
+    return () => clearTimeout(timeout);
+  }, [session, isLoading, router]);
+
+  return (
+    <View className="flex-1 items-center justify-center bg-f1-black">
+      <ActivityIndicator color="#CF2637" />
+    </View>
+  );
+}

--- a/apps/mobile/src/components/predictions/ConfirmModal.tsx
+++ b/apps/mobile/src/components/predictions/ConfirmModal.tsx
@@ -1,0 +1,82 @@
+import { ActivityIndicator, Modal, Pressable, Text, View } from "react-native";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+interface ConfirmModalProps {
+  visible: boolean;
+  title: string;
+  /** Small subtitle under the title, e.g. the race name. */
+  subtitle?: string;
+  body: string;
+  confirmLabel: string;
+  /** Label swapped in while the request is in flight. */
+  confirmingLabel: string;
+  /** Visual tone of the confirm button. */
+  tone: "red" | "blue";
+  isSaving: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Centered confirmation dialog used before destructive or overwriting
+ * actions (reset prediction, update an already-submitted prediction).
+ */
+export function ConfirmModal({
+  visible,
+  title,
+  subtitle,
+  body,
+  confirmLabel,
+  confirmingLabel,
+  tone,
+  isSaving,
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  const { t } = useLanguage();
+  const confirmBg = tone === "red" ? "bg-f1-red active:bg-f1-red-hover" : "bg-f1-blue active:bg-f1-blue/80";
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
+      <View className="flex-1 items-center justify-center bg-black/60 p-6">
+        <View className="w-full max-w-sm overflow-hidden rounded-2xl border border-f1-white/10 bg-f1-black">
+          <View className="border-b border-f1-white/10 px-5 py-4">
+            <Text className="text-base font-semibold text-f1-white">{title}</Text>
+            {subtitle ? <Text className="mt-0.5 text-xs text-f1-white/50">{subtitle}</Text> : null}
+          </View>
+          <View className="px-5 py-4">
+            <Text className="text-sm leading-5 text-f1-white/70">{body}</Text>
+          </View>
+          <View className="flex-row items-center justify-end gap-2 border-t border-f1-white/10 px-5 py-3">
+            <Pressable
+              onPress={onCancel}
+              disabled={isSaving}
+              accessibilityRole="button"
+              accessibilityLabel={t.navbar.cancel}
+              className={`min-h-11 items-center justify-center rounded-lg border border-f1-white/10 px-4 active:bg-f1-white/10 ${
+                isSaving ? "opacity-50" : ""
+              }`}
+            >
+              <Text className="text-sm font-medium text-f1-white/70">{t.navbar.cancel}</Text>
+            </Pressable>
+            <Pressable
+              onPress={onConfirm}
+              disabled={isSaving}
+              accessibilityRole="button"
+              accessibilityLabel={confirmLabel}
+              className={`min-h-11 flex-row items-center justify-center gap-2 rounded-lg px-4 ${confirmBg} ${
+                isSaving ? "opacity-70" : ""
+              }`}
+            >
+              {isSaving ? <ActivityIndicator size="small" color="#FFFFFF" /> : null}
+              <Text className="text-sm font-semibold text-white">
+                {isSaving ? confirmingLabel : confirmLabel}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/components/predictions/CountdownBar.tsx
+++ b/apps/mobile/src/components/predictions/CountdownBar.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from "react";
+import { Text, View } from "react-native";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+function computeTimeLeft(target: string) {
+  const diff = new Date(target).getTime() - Date.now();
+  if (diff <= 0) return null;
+  return {
+    days: Math.floor(diff / (1000 * 60 * 60 * 24)),
+    hours: Math.floor((diff / (1000 * 60 * 60)) % 24),
+    minutes: Math.floor((diff / (1000 * 60)) % 60),
+    seconds: Math.floor((diff / 1000) % 60),
+  };
+}
+
+/**
+ * Live d:h:m:s countdown to the prediction deadline (qualifying start).
+ * Only mounted while the deadline is open, so the 1s interval never runs
+ * on locked or completed rounds. Calls `onExpire` once when it hits zero.
+ */
+export function CountdownBar({ deadline, onExpire }: { deadline: string; onExpire: () => void }) {
+  const { t, language } = useLanguage();
+  const [timeLeft, setTimeLeft] = useState(() => computeTimeLeft(deadline));
+  const onExpireRef = useRef(onExpire);
+  onExpireRef.current = onExpire;
+
+  useEffect(() => {
+    setTimeLeft(computeTimeLeft(deadline));
+    const timer = setInterval(() => {
+      const next = computeTimeLeft(deadline);
+      setTimeLeft(next);
+      if (next === null) {
+        clearInterval(timer);
+        onExpireRef.current();
+      }
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [deadline]);
+
+  if (!timeLeft) return null;
+
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const numeric = `${pad(timeLeft.days)}:${pad(timeLeft.hours)}:${pad(timeLeft.minutes)}:${pad(timeLeft.seconds)}`;
+  const announce =
+    language === "es"
+      ? `${timeLeft.days} días, ${timeLeft.hours} horas, ${timeLeft.minutes} minutos`
+      : `${timeLeft.days} days, ${timeLeft.hours} hours, ${timeLeft.minutes} minutes`;
+
+  return (
+    <View
+      accessibilityRole="text"
+      accessibilityLabel={`${t.predictionsPage.predictionDeadline}: ${announce}`}
+      className="flex-row items-center gap-2 rounded-lg border border-f1-amber/30 bg-f1-amber/10 px-3 py-2"
+    >
+      <Text className="flex-1 text-xs font-medium text-f1-amber">
+        {t.predictionsPage.predictionDeadline}
+      </Text>
+      <Text className="text-sm font-bold tabular-nums text-f1-white">{numeric}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/predictions/DriverPickerModal.tsx
+++ b/apps/mobile/src/components/predictions/DriverPickerModal.tsx
@@ -1,0 +1,141 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Image } from "expo-image";
+import { FlatList, Modal, Pressable, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import type { Driver } from "@f1/shared/types";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+interface DriverPickerModalProps {
+  visible: boolean;
+  /** Slot label shown in the sheet header, e.g. "Q1" or "Fastest Lap". */
+  label: string;
+  drivers: Driver[];
+  value: Driver | null;
+  /** Drivers that cannot be picked for this slot (already used elsewhere). */
+  disabledDrivers: Driver[];
+  /** Called with the picked driver, or null when clearing the selection. */
+  onSelect: (driver: Driver | null) => void;
+  onClose: () => void;
+}
+
+/**
+ * Bottom-sheet-style driver picker: dark card sliding up from the bottom
+ * with one comfortably tappable row per driver (team color bar, number,
+ * name, team). Disabled rows are greyed out with a translated reason.
+ */
+export function DriverPickerModal({
+  visible,
+  label,
+  drivers,
+  value,
+  disabledDrivers,
+  onSelect,
+  onClose,
+}: DriverPickerModalProps) {
+  const { t } = useLanguage();
+  const insets = useSafeAreaInsets();
+
+  const isDisabled = (driver: Driver) =>
+    disabledDrivers.some((d) => d.driverNumber === driver.driverNumber);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View className="flex-1 justify-end bg-black/60">
+        <Pressable
+          className="flex-1"
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel={t.predictionsPage.dismiss}
+        />
+        <View
+          className="max-h-[75%] rounded-t-3xl border-t border-f1-white/10 bg-f1-black"
+          style={{ paddingBottom: insets.bottom }}
+        >
+          {/* Header */}
+          <View className="flex-row items-center justify-between border-b border-f1-white/10 px-5 py-4">
+            <Text className="text-sm font-bold uppercase tracking-wider text-f1-white">
+              {label}
+            </Text>
+            <Pressable
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel={t.predictionsPage.dismiss}
+              className="h-8 w-8 items-center justify-center rounded-full bg-f1-white/10 active:bg-f1-white/20"
+            >
+              <Ionicons name="close" size={16} color="#F7F7F7" />
+            </Pressable>
+          </View>
+
+          <FlatList
+            data={drivers}
+            keyExtractor={(d) => String(d.driverNumber)}
+            ListHeaderComponent={
+              value ? (
+                <Pressable
+                  onPress={() => onSelect(null)}
+                  accessibilityRole="button"
+                  accessibilityLabel={t.predictionsPage.clearSelection}
+                  className="min-h-12 flex-row items-center gap-3 border-b border-f1-white/10 px-5 py-3 active:bg-f1-white/10"
+                >
+                  <Ionicons name="close-circle-outline" size={20} color="#CF2637" />
+                  <Text className="text-sm font-semibold text-f1-red">
+                    {t.predictionsPage.clearSelection}
+                  </Text>
+                </Pressable>
+              ) : null
+            }
+            renderItem={({ item: driver }) => {
+              const unavailable = isDisabled(driver);
+              const selected = value?.driverNumber === driver.driverNumber;
+              return (
+                <Pressable
+                  onPress={() => !unavailable && onSelect(driver)}
+                  disabled={unavailable}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${driver.firstName} ${driver.lastName}, ${driver.teamName}${
+                    unavailable ? `, ${t.predictionsPage.alreadySelected}` : ""
+                  }`}
+                  accessibilityState={{ disabled: unavailable, selected }}
+                  className={`min-h-14 flex-row items-center gap-3 px-5 py-2.5 ${
+                    selected ? "bg-f1-red/10" : unavailable ? "opacity-35" : "active:bg-f1-white/10"
+                  }`}
+                >
+                  <View
+                    className="h-9 w-1.5 rounded-full"
+                    style={{ backgroundColor: `#${driver.teamColor}` }}
+                  />
+                  <Text className="w-8 text-center text-sm font-bold tabular-nums text-f1-white/50">
+                    {driver.driverNumber}
+                  </Text>
+                  {driver.headshotUrl ? (
+                    <Image
+                      source={{ uri: driver.headshotUrl }}
+                      contentFit="cover"
+                      className="h-9 w-9 rounded-full bg-f1-white/10"
+                    />
+                  ) : null}
+                  <View className="flex-1">
+                    <Text className="text-sm font-semibold text-f1-white" numberOfLines={1}>
+                      {driver.firstName} {driver.lastName}
+                    </Text>
+                    <Text className="text-xs text-f1-white/50" numberOfLines={1}>
+                      {driver.teamName}
+                    </Text>
+                  </View>
+                  {unavailable ? (
+                    <Text className="text-[10px] font-medium text-f1-white/40">
+                      {t.predictionsPage.alreadySelected}
+                    </Text>
+                  ) : selected ? (
+                    <Ionicons name="checkmark" size={16} color="#CF2637" />
+                  ) : null}
+                </Pressable>
+              );
+            }}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/components/predictions/DriverSlot.tsx
+++ b/apps/mobile/src/components/predictions/DriverSlot.tsx
@@ -1,0 +1,71 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Pressable, Text, View } from "react-native";
+import type { Driver } from "@f1/shared/types";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+interface DriverSlotProps {
+  /** Slot label, e.g. "Q1", "Race Winner (P1)", "Fastest Lap". */
+  label: string;
+  /** Optional numeric position rendered as a "P{n}" prefix (rest of top 10). */
+  position?: number;
+  value: Driver | null;
+  disabled?: boolean;
+  onPress: () => void;
+}
+
+/**
+ * A single tappable prediction slot. Tapping opens the DriverPickerModal;
+ * this component only renders the current selection.
+ */
+export function DriverSlot({ label, position, value, disabled = false, onPress }: DriverSlotProps) {
+  const { t } = useLanguage();
+  const placeholder = t.predictionsPage.selectDriverPlaceholder;
+  const valueLabel = value ? `${value.firstName} ${value.lastName}` : placeholder;
+  const fullLabel = position !== undefined ? `P${position} ${label}`.trim() : label;
+
+  return (
+    <View className="gap-1">
+      <View className="flex-row items-center gap-1">
+        {position !== undefined && (
+          <Text className="text-[10px] font-semibold tabular-nums text-f1-white/40">
+            P{position}
+          </Text>
+        )}
+        {label.length > 0 && (
+          <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-white/60">
+            {label}
+          </Text>
+        )}
+      </View>
+      <Pressable
+        onPress={onPress}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityLabel={`${fullLabel}: ${valueLabel}`}
+        accessibilityState={{ disabled }}
+        className={`min-h-12 flex-row items-center gap-2 rounded-xl border px-3 py-2.5 ${
+          disabled
+            ? "border-f1-white/5 bg-f1-white/5 opacity-60"
+            : "border-f1-white/10 bg-f1-white/5 active:bg-f1-white/10"
+        }`}
+      >
+        {value ? (
+          <>
+            <View
+              className="h-6 w-1.5 rounded-full"
+              style={{ backgroundColor: `#${value.teamColor}` }}
+            />
+            <Text className="font-bold text-f1-white">{value.nameAcronym}</Text>
+            <Text className="flex-1 text-f1-white/60" numberOfLines={1}>
+              {value.firstName} {value.lastName}
+            </Text>
+          </>
+        ) : (
+          <Text className="flex-1 text-f1-white/40">{placeholder}</Text>
+        )}
+        <Ionicons name="chevron-down" size={14} color="#F7F7F766" />
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/predictions/RoundSelectorModal.tsx
+++ b/apps/mobile/src/components/predictions/RoundSelectorModal.tsx
@@ -1,0 +1,105 @@
+import { Ionicons } from "@expo/vector-icons";
+import { FlatList, Modal, Pressable, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { countryCodeToFlag, getRaceStatus } from "@f1/shared/lib/race-utils";
+import type { Race } from "@f1/shared/types";
+
+import { RaceStatusBadge } from "@/components/predictions/StatusBadges";
+import { useLanguage } from "@/providers/LanguageProvider";
+
+interface RoundSelectorModalProps {
+  visible: boolean;
+  races: Race[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+  onClose: () => void;
+}
+
+/**
+ * Bottom-sheet listing every round of the season. The currently selected
+ * round is highlighted; each row shows the flag, round number, race name
+ * and its live/upcoming/completed status badge.
+ */
+export function RoundSelectorModal({
+  visible,
+  races,
+  selectedIndex,
+  onSelect,
+  onClose,
+}: RoundSelectorModalProps) {
+  const { t, language } = useLanguage();
+  const insets = useSafeAreaInsets();
+
+  const formatDate = (dateStr: string) =>
+    new Date(dateStr).toLocaleDateString(language === "es" ? "es-ES" : "en-US", {
+      month: "short",
+      day: "numeric",
+    });
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View className="flex-1 justify-end bg-black/60">
+        <Pressable
+          className="flex-1"
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel={t.predictionsPage.dismiss}
+        />
+        <View
+          className="max-h-[80%] rounded-t-3xl border-t border-f1-white/10 bg-f1-black"
+          style={{ paddingBottom: insets.bottom }}
+        >
+          <View className="flex-row items-center justify-between border-b border-f1-white/10 px-5 py-4">
+            <Text className="text-sm font-bold uppercase tracking-wider text-f1-white">
+              {t.predictionsPage.jumpToRound}
+            </Text>
+            <Pressable
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel={t.predictionsPage.dismiss}
+              className="h-8 w-8 items-center justify-center rounded-full bg-f1-white/10 active:bg-f1-white/20"
+            >
+              <Ionicons name="close" size={16} color="#F7F7F7" />
+            </Pressable>
+          </View>
+
+          <FlatList
+            data={races}
+            keyExtractor={(race) => String(race.meetingKey)}
+            renderItem={({ item: race, index }) => {
+              const isSelected = index === selectedIndex;
+              return (
+                <Pressable
+                  onPress={() => onSelect(index)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`R${race.round} ${race.raceName}`}
+                  accessibilityState={{ selected: isSelected }}
+                  className={`min-h-14 flex-row items-center gap-3 border-l-2 px-5 py-2.5 ${
+                    isSelected ? "border-f1-red bg-f1-red/10" : "border-transparent active:bg-f1-white/10"
+                  }`}
+                >
+                  <Text className="text-lg">{countryCodeToFlag(race.countryCode)}</Text>
+                  <Text className="w-9 text-xs font-bold tabular-nums text-f1-white/50">
+                    R{String(race.round).padStart(2, "0")}
+                  </Text>
+                  <View className="flex-1">
+                    <Text
+                      className={`text-sm font-semibold ${isSelected ? "text-f1-red" : "text-f1-white"}`}
+                      numberOfLines={1}
+                    >
+                      {race.raceName}
+                    </Text>
+                    <Text className="text-xs text-f1-white/50">
+                      {formatDate(race.dateStart)} – {formatDate(race.dateEnd)}
+                    </Text>
+                  </View>
+                  <RaceStatusBadge status={getRaceStatus(race)} />
+                </Pressable>
+              );
+            }}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/components/predictions/StatusBadges.tsx
+++ b/apps/mobile/src/components/predictions/StatusBadges.tsx
@@ -1,0 +1,39 @@
+import { Text, View } from "react-native";
+import type { PredictionStatus, RaceStatus } from "@f1/shared/types";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+/**
+ * Small pill badges mirroring the web prediction page: one for the
+ * prediction lifecycle (pending / submitted / scored) and one for the
+ * race weekend status (upcoming / live / completed).
+ */
+export function PredictionStatusBadge({ status }: { status: PredictionStatus }) {
+  const { t } = useLanguage();
+  const config: Record<PredictionStatus, { bg: string; text: string; label: string }> = {
+    pending: { bg: "bg-f1-amber/15", text: "text-f1-amber", label: t.predictionsPage.pending },
+    submitted: { bg: "bg-f1-blue/15", text: "text-f1-blue", label: t.predictionsPage.submitted },
+    scored: { bg: "bg-f1-green/15", text: "text-f1-green", label: t.predictionsPage.scored },
+  };
+  const c = config[status];
+  return (
+    <View className={`self-start rounded-full px-2.5 py-1 ${c.bg}`}>
+      <Text className={`text-[11px] font-semibold ${c.text}`}>{c.label}</Text>
+    </View>
+  );
+}
+
+export function RaceStatusBadge({ status }: { status: RaceStatus }) {
+  const { t } = useLanguage();
+  const config: Record<RaceStatus, { bg: string; text: string; label: string }> = {
+    upcoming: { bg: "bg-f1-blue/15", text: "text-f1-blue", label: t.predictionsPage.upcoming },
+    live: { bg: "bg-f1-red/15", text: "text-f1-red", label: t.predictionsPage.live },
+    completed: { bg: "bg-f1-green/15", text: "text-f1-green", label: t.predictionsPage.completed },
+  };
+  const c = config[status];
+  return (
+    <View className={`self-start rounded-full px-2.5 py-1 ${c.bg}`}>
+      <Text className={`text-[11px] font-semibold ${c.text}`}>{c.label}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,0 +1,32 @@
+import { supabase } from "@/lib/supabase";
+
+/**
+ * Thin authenticated fetch helper for the shared Next.js backend
+ * (the 11 API routes in apps/web/app/api).
+ *
+ * The mobile app has no auth cookies, so every request carries the
+ * Supabase access token as a Bearer header instead. Callers receive the
+ * raw Response and are responsible for checking `res.ok` and parsing the
+ * `{ error }` body — the same contract the web components follow.
+ */
+export async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const baseUrl = process.env.EXPO_PUBLIC_API_URL;
+  if (!baseUrl) {
+    throw new Error(
+      "EXPO_PUBLIC_API_URL is not set. Add it to apps/mobile/.env — see apps/mobile/.env.example."
+    );
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  return fetch(`${baseUrl.replace(/\/+$/, "")}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+      ...init.headers,
+    },
+  });
+}

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -21,7 +21,7 @@ export async function apiFetch(path: string, init: RequestInit = {}): Promise<Re
     data: { session },
   } = await supabase.auth.getSession();
 
-  return fetch(`${baseUrl.replace(/\/+$/, "")}${path}`, {
+  const res = await fetch(`${baseUrl.replace(/\/+$/, "")}${path}`, {
     ...init,
     headers: {
       "Content-Type": "application/json",
@@ -29,4 +29,13 @@ export async function apiFetch(path: string, init: RequestInit = {}): Promise<Re
       ...init.headers,
     },
   });
+
+  // The API always answers JSON. Anything else means the request never
+  // reached the route handler (e.g. a redirect to an HTML page) — surface
+  // that as an error instead of letting an HTML 200 pass as success.
+  if (res.ok && !res.headers.get("content-type")?.includes("application/json")) {
+    throw new Error(`Unexpected non-JSON response from ${path} (status ${res.status})`);
+  }
+
+  return res;
 }

--- a/apps/web/__tests__/lib/prediction-status.test.ts
+++ b/apps/web/__tests__/lib/prediction-status.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for packages/shared/lib/prediction-status.ts — pure function, no mocks.
+ */
+import { proximityStatus } from "@f1/shared/lib/prediction-status";
+import type { Driver } from "@f1/shared/types";
+
+function makeDriver(driverNumber: number, acronym = `D${driverNumber}`): Driver {
+  return {
+    driverNumber,
+    firstName: `First${driverNumber}`,
+    lastName: `Last${driverNumber}`,
+    nameAcronym: acronym,
+    teamName: "Team",
+    teamColor: "FF0000",
+  };
+}
+
+// Ordered result: P1=#1, P2=#2, ... P10=#10
+const top10 = Array.from({ length: 10 }, (_, i) => makeDriver(i + 1));
+const p11 = makeDriver(11);
+
+describe("proximityStatus", () => {
+  it("returns null when no driver is predicted for the slot", () => {
+    expect(proximityStatus(null, top10, p11, 10, 0)).toBeNull();
+  });
+
+  it("returns 'exact' when the predicted driver finished in the exact slot position", () => {
+    expect(proximityStatus(makeDriver(1), top10, p11, 10, 0)).toBe("exact");
+    expect(proximityStatus(makeDriver(5), top10, p11, 10, 4)).toBe("exact");
+    expect(proximityStatus(makeDriver(10), top10, p11, 10, 9)).toBe("exact");
+  });
+
+  it("returns 'close' when the predicted driver finished one position ahead", () => {
+    // Predicted P5 (slot 4) but finished P4 (index 3)
+    expect(proximityStatus(makeDriver(4), top10, p11, 10, 4)).toBe("close");
+  });
+
+  it("returns 'close' when the predicted driver finished one position behind", () => {
+    // Predicted P5 (slot 4) but finished P6 (index 5)
+    expect(proximityStatus(makeDriver(6), top10, p11, 10, 4)).toBe("close");
+  });
+
+  it("returns 'miss' when the predicted driver finished two or more positions away", () => {
+    // Predicted P1 (slot 0) but finished P3 (index 2)
+    expect(proximityStatus(makeDriver(3), top10, p11, 10, 0)).toBe("miss");
+    // Predicted P10 (slot 9) but finished P1 (index 0)
+    expect(proximityStatus(makeDriver(1), top10, p11, 10, 9)).toBe("miss");
+  });
+
+  it("returns 'miss' when the predicted driver is not in the results at all", () => {
+    expect(proximityStatus(makeDriver(99), top10, p11, 10, 3)).toBe("miss");
+  });
+
+  it("returns 'close' for the last slot when the boundary driver is predicted there", () => {
+    // Boundary driver sits at index `count` (P11) — predicted at slot 9 (P10) → delta 1
+    expect(proximityStatus(p11, top10, p11, 10, 9)).toBe("close");
+  });
+
+  it("returns 'miss' when the boundary driver is predicted two slots from the boundary", () => {
+    // Boundary at index 10; predicted at slot 8 (P9) → delta 2
+    expect(proximityStatus(p11, top10, p11, 10, 8)).toBe("miss");
+  });
+
+  it("works without a boundary driver", () => {
+    expect(proximityStatus(makeDriver(11), top10, null, 10, 9)).toBe("miss");
+    expect(proximityStatus(makeDriver(3), top10, null, 10, 2)).toBe("exact");
+  });
+
+  it("respects the count parameter for shorter result sets (qualifying top 3)", () => {
+    const quali = [makeDriver(1), makeDriver(2), makeDriver(3)];
+    const q4 = makeDriver(4);
+    expect(proximityStatus(makeDriver(3), quali, q4, 3, 2)).toBe("exact");
+    expect(proximityStatus(q4, quali, q4, 3, 2)).toBe("close");
+    // Driver #5 outside quali results entirely
+    expect(proximityStatus(makeDriver(5), quali, q4, 3, 2)).toBe("miss");
+  });
+
+  it("keeps the first position when duplicate driver numbers appear in results", () => {
+    const withDuplicate = [
+      makeDriver(1),
+      makeDriver(2),
+      makeDriver(1), // duplicate of P1's driver number at index 2
+      makeDriver(4),
+    ];
+    // First occurrence (index 0) wins: slot 0 → exact, slot 2 → miss
+    expect(proximityStatus(makeDriver(1), withDuplicate, null, 4, 0)).toBe("exact");
+    expect(proximityStatus(makeDriver(1), withDuplicate, null, 4, 2)).toBe("miss");
+  });
+
+  it("does not let the boundary driver override an existing result position", () => {
+    // Boundary duplicates the P1 driver — the map keeps index 0
+    expect(proximityStatus(makeDriver(1), top10, makeDriver(1), 10, 0)).toBe("exact");
+  });
+
+  it("skips undefined result slots without crashing", () => {
+    const sparse = [makeDriver(1), undefined as unknown as Driver, makeDriver(3)];
+    expect(proximityStatus(makeDriver(3), sparse, null, 3, 2)).toBe("exact");
+    expect(proximityStatus(makeDriver(2), sparse, null, 3, 1)).toBe("miss");
+  });
+});

--- a/apps/web/__tests__/lib/predictions.test.ts
+++ b/apps/web/__tests__/lib/predictions.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for packages/shared/lib/predictions.ts — service layer with mocked Supabase.
+ *
+ * Covers: fetchUserRacePredictions
+ *
+ * Query order inside fetchUserRacePredictions (matters for the mock queues):
+ *   1. seasons (is_current)              — also re-queried inside fetchDrivers (sticky)
+ *   2. drivers (id, driver_number map)   — first "drivers" queue entry
+ *   3. races   (id, meeting_key map)
+ *   4. drivers (full rows, fetchDrivers) — second "drivers" queue entry
+ *   5. race_predictions (user rows)
+ */
+import { createMockSupabase } from "../helpers/mockSupabase";
+import { fetchUserRacePredictions } from "@f1/shared/lib/predictions";
+import type { Race } from "@f1/shared/types";
+
+const USER_ID = "user-123";
+const SEASON_ID = 7;
+
+function makeRace(meetingKey: number, round: number): Race {
+  return {
+    meetingKey,
+    raceName: `Race ${round}`,
+    officialName: `Official Race ${round}`,
+    circuitShortName: `Circuit ${round}`,
+    countryName: "Country",
+    countryCode: "CC",
+    location: "Location",
+    dateStart: "2026-03-01T00:00:00Z",
+    dateEnd: "2026-03-03T00:00:00Z",
+    sprintDateEnd: null,
+    round,
+    hasSprint: false,
+  };
+}
+
+/** DB driver id = 100 + driver number; 12 drivers, numbers 1..12. */
+const DRIVER_ID_ROWS = Array.from({ length: 12 }, (_, i) => ({
+  id: 101 + i,
+  driver_number: i + 1,
+}));
+
+const FULL_DRIVER_ROWS = Array.from({ length: 12 }, (_, i) => ({
+  driver_number: i + 1,
+  first_name: `First${i + 1}`,
+  last_name: `Last${i + 1}`,
+  name_acronym: `D${i + 1}`,
+  headshot_url: null,
+  team_id: 1,
+  teams: { name: "Team", color: "FF0000" },
+}));
+
+const DB_RACES = [
+  { id: 501, meeting_key: 9001 },
+  { id: 502, meeting_key: 9002 },
+];
+
+/** Standard fixture: current season, 12 drivers, 2 races. */
+function setupBase() {
+  const { supabase, mockTable } = createMockSupabase();
+  mockTable("seasons", { data: { id: SEASON_ID }, error: null });
+  mockTable(
+    "drivers",
+    { data: DRIVER_ID_ROWS, error: null },
+    { data: FULL_DRIVER_ROWS, error: null }
+  );
+  mockTable("races", { data: DB_RACES, error: null });
+  return { supabase, mockTable };
+}
+
+describe("fetchUserRacePredictions", () => {
+  it("returns an empty array when there is no current season", async () => {
+    const { supabase, mockTable } = createMockSupabase();
+    mockTable("seasons", { data: null, error: null });
+
+    const result = await fetchUserRacePredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns a pending placeholder with all-null slots for each race when the user has no prediction rows", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_predictions", { data: null, error: null });
+
+    const races = [makeRace(9001, 1), makeRace(9002, 2)];
+    const result = await fetchUserRacePredictions(supabase, USER_ID, races);
+
+    expect(result).toHaveLength(2);
+    for (let i = 0; i < 2; i++) {
+      expect(result[i]).toEqual({
+        raceId: races[i].meetingKey,
+        userId: USER_ID,
+        status: "pending",
+        qualifyingTop3: [null, null, null],
+        raceWinner: null,
+        restOfTop10: Array(9).fill(null),
+        fastestLap: null,
+        fastestPitStop: null,
+        driverOfTheDay: null,
+        pointsEarned: null,
+      });
+    }
+  });
+
+  it("maps a full stored prediction: winner from top_10[0], rest from indexes 1..9, quali, specials, points, status", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_predictions", {
+      data: [
+        {
+          race_id: 501,
+          status: "scored",
+          pole_position_driver_id: 103, // must be ignored when qualifying_top_3 is set
+          qualifying_top_3: [103, 101, 102],
+          top_10: [101, 102, 103, 104, 105, 106, 107, 108, 109, 110],
+          fastest_lap_driver_id: 104,
+          fastest_pit_stop_driver_id: 105,
+          driver_of_the_day_driver_id: 106,
+          points_earned: 42,
+        },
+      ],
+      error: null,
+    });
+
+    const [prediction] = await fetchUserRacePredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+
+    expect(prediction.raceId).toBe(9001);
+    expect(prediction.userId).toBe(USER_ID);
+    expect(prediction.status).toBe("scored");
+    expect(prediction.pointsEarned).toBe(42);
+
+    expect(prediction.raceWinner?.driverNumber).toBe(1);
+    expect(prediction.raceWinner?.nameAcronym).toBe("D1");
+    expect(prediction.restOfTop10).toHaveLength(9);
+    expect(prediction.restOfTop10.map((d) => d?.driverNumber)).toEqual([
+      2, 3, 4, 5, 6, 7, 8, 9, 10,
+    ]);
+
+    expect(prediction.qualifyingTop3.map((d) => d?.driverNumber ?? null)).toEqual([3, 1, 2]);
+    expect(prediction.fastestLap?.driverNumber).toBe(4);
+    expect(prediction.fastestPitStop?.driverNumber).toBe(5);
+    expect(prediction.driverOfTheDay?.driverNumber).toBe(6);
+  });
+
+  it("resolves full Driver objects with team info", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_predictions", {
+      data: [
+        {
+          race_id: 501,
+          status: "submitted",
+          pole_position_driver_id: null,
+          qualifying_top_3: [101],
+          top_10: [101],
+          fastest_lap_driver_id: null,
+          fastest_pit_stop_driver_id: null,
+          driver_of_the_day_driver_id: null,
+          points_earned: null,
+        },
+      ],
+      error: null,
+    });
+
+    const [prediction] = await fetchUserRacePredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(prediction.raceWinner).toEqual({
+      driverNumber: 1,
+      firstName: "First1",
+      lastName: "Last1",
+      nameAcronym: "D1",
+      teamName: "Team",
+      teamColor: "FF0000",
+      teamId: 1,
+      headshotUrl: undefined,
+    });
+    expect(prediction.pointsEarned).toBeNull();
+  });
+
+  it("falls back to the legacy pole_position_driver_id as Q1 when qualifying_top_3 is null", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_predictions", {
+      data: [
+        {
+          race_id: 501,
+          status: "submitted",
+          pole_position_driver_id: 107,
+          qualifying_top_3: null,
+          top_10: [101],
+          fastest_lap_driver_id: null,
+          fastest_pit_stop_driver_id: null,
+          driver_of_the_day_driver_id: null,
+          points_earned: null,
+        },
+      ],
+      error: null,
+    });
+
+    const [prediction] = await fetchUserRacePredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(prediction.qualifyingTop3.map((d) => d?.driverNumber ?? null)).toEqual([7, null, null]);
+  });
+
+  it("falls back to the legacy pole_position_driver_id when qualifying_top_3 is an empty array", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_predictions", {
+      data: [
+        {
+          race_id: 501,
+          status: "submitted",
+          pole_position_driver_id: 108,
+          qualifying_top_3: [],
+          top_10: [],
+          fastest_lap_driver_id: null,
+          fastest_pit_stop_driver_id: null,
+          driver_of_the_day_driver_id: null,
+          points_earned: null,
+        },
+      ],
+      error: null,
+    });
+
+    const [prediction] = await fetchUserRacePredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(prediction.qualifyingTop3.map((d) => d?.driverNumber ?? null)).toEqual([8, null, null]);
+    expect(prediction.raceWinner).toBeNull();
+  });
+
+  it("leaves qualifying all-null when both qualifying_top_3 and the legacy pole are empty", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_predictions", {
+      data: [
+        {
+          race_id: 501,
+          status: "submitted",
+          pole_position_driver_id: null,
+          qualifying_top_3: null,
+          top_10: [101],
+          fastest_lap_driver_id: null,
+          fastest_pit_stop_driver_id: null,
+          driver_of_the_day_driver_id: null,
+          points_earned: null,
+        },
+      ],
+      error: null,
+    });
+
+    const [prediction] = await fetchUserRacePredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(prediction.qualifyingTop3).toEqual([null, null, null]);
+  });
+
+  it("ignores prediction rows whose race_id does not map to a passed race", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_predictions", {
+      data: [
+        {
+          race_id: 999, // not in the season's races
+          status: "scored",
+          pole_position_driver_id: 101,
+          qualifying_top_3: [101, 102, 103],
+          top_10: [101, 102, 103],
+          fastest_lap_driver_id: 101,
+          fastest_pit_stop_driver_id: 101,
+          driver_of_the_day_driver_id: 101,
+          points_earned: 99,
+        },
+      ],
+      error: null,
+    });
+
+    const [prediction] = await fetchUserRacePredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(prediction.status).toBe("pending");
+    expect(prediction.raceWinner).toBeNull();
+    expect(prediction.pointsEarned).toBeNull();
+  });
+
+  it("resolves unknown driver ids to null while keeping known ones", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_predictions", {
+      data: [
+        {
+          race_id: 501,
+          status: "submitted",
+          pole_position_driver_id: null,
+          qualifying_top_3: [9999, 101, null], // 9999 has no id → number mapping
+          top_10: [9999, 102],
+          fastest_lap_driver_id: 9999,
+          fastest_pit_stop_driver_id: 103,
+          driver_of_the_day_driver_id: null,
+          points_earned: null,
+        },
+      ],
+      error: null,
+    });
+
+    const [prediction] = await fetchUserRacePredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(prediction.qualifyingTop3.map((d) => d?.driverNumber ?? null)).toEqual([null, 1, null]);
+    expect(prediction.raceWinner).toBeNull();
+    expect(prediction.restOfTop10[0]?.driverNumber).toBe(2);
+    expect(prediction.fastestLap).toBeNull();
+    expect(prediction.fastestPitStop?.driverNumber).toBe(3);
+  });
+
+  it("resolves a driver id to null when its driver number has no active driver row", async () => {
+    const { supabase, mockTable } = createMockSupabase();
+    mockTable("seasons", { data: { id: SEASON_ID }, error: null });
+    mockTable(
+      "drivers",
+      // Mapping knows id 199 → number 99, but the full driver list has no #99
+      { data: [...DRIVER_ID_ROWS, { id: 199, driver_number: 99 }], error: null },
+      { data: FULL_DRIVER_ROWS, error: null }
+    );
+    mockTable("races", { data: DB_RACES, error: null });
+    mockTable("race_predictions", {
+      data: [
+        {
+          race_id: 501,
+          status: "submitted",
+          pole_position_driver_id: null,
+          qualifying_top_3: [199],
+          top_10: [199, 101],
+          fastest_lap_driver_id: null,
+          fastest_pit_stop_driver_id: null,
+          driver_of_the_day_driver_id: null,
+          points_earned: null,
+        },
+      ],
+      error: null,
+    });
+
+    const [prediction] = await fetchUserRacePredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(prediction.qualifyingTop3[0]).toBeNull();
+    expect(prediction.raceWinner).toBeNull();
+    expect(prediction.restOfTop10[0]?.driverNumber).toBe(1);
+  });
+
+  it("returns an empty array when no races are passed", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_predictions", { data: null, error: null });
+
+    const result = await fetchUserRacePredictions(supabase, USER_ID, []);
+    expect(result).toEqual([]);
+  });
+
+  it("pads a short top_10 with nulls in the remaining slots", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_predictions", {
+      data: [
+        {
+          race_id: 501,
+          status: "submitted",
+          pole_position_driver_id: null,
+          qualifying_top_3: [101, 102, 103],
+          top_10: [101, 102, 103], // only P1-P3 stored
+          fastest_lap_driver_id: null,
+          fastest_pit_stop_driver_id: null,
+          driver_of_the_day_driver_id: null,
+          points_earned: null,
+        },
+      ],
+      error: null,
+    });
+
+    const [prediction] = await fetchUserRacePredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(prediction.raceWinner?.driverNumber).toBe(1);
+    expect(prediction.restOfTop10.map((d) => d?.driverNumber ?? null)).toEqual([
+      2, 3, null, null, null, null, null, null, null,
+    ]);
+  });
+
+  it("maps predictions for multiple races independently", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_predictions", {
+      data: [
+        {
+          race_id: 502,
+          status: "submitted",
+          pole_position_driver_id: null,
+          qualifying_top_3: [101, 102, 103],
+          top_10: [104],
+          fastest_lap_driver_id: null,
+          fastest_pit_stop_driver_id: null,
+          driver_of_the_day_driver_id: null,
+          points_earned: null,
+        },
+      ],
+      error: null,
+    });
+
+    const result = await fetchUserRacePredictions(supabase, USER_ID, [
+      makeRace(9001, 1),
+      makeRace(9002, 2),
+    ]);
+
+    expect(result[0].status).toBe("pending");
+    expect(result[0].raceWinner).toBeNull();
+    expect(result[1].status).toBe("submitted");
+    expect(result[1].raceWinner?.driverNumber).toBe(4);
+  });
+});

--- a/apps/web/__tests__/lib/supabase-server.test.ts
+++ b/apps/web/__tests__/lib/supabase-server.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for apps/web/lib/supabase/server.ts — bearer-token vs cookie client creation.
+ *
+ * Mocks next/headers (cookies + headers) and @supabase/ssr's createServerClient
+ * to verify which path createClient() takes and what options it passes.
+ */
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+  headers: jest.fn(),
+}));
+
+jest.mock("@supabase/ssr", () => ({
+  createServerClient: jest.fn(),
+}));
+
+import { cookies, headers } from "next/headers";
+import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@/lib/supabase/server";
+
+const mockHeaders = headers as jest.Mock;
+const mockCookies = cookies as jest.Mock;
+const mockCreateServerClient = createServerClient as jest.Mock;
+
+const SUPABASE_URL = "https://example.supabase.co";
+const SUPABASE_ANON_KEY = "anon-key";
+
+function makeHeaderStore(authValue: string | null) {
+  return {
+    get: jest.fn((name: string) => (name.toLowerCase() === "authorization" ? authValue : null)),
+  };
+}
+
+function makeCookieStore() {
+  return {
+    getAll: jest.fn(() => [{ name: "sb-token", value: "cookie-value" }]),
+    set: jest.fn(),
+  };
+}
+
+/** A minimal client whose auth.getUser we can spy on. */
+function makeSsrClient() {
+  return {
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user: { id: "user-1" } }, error: null }),
+    },
+  };
+}
+
+describe("createClient (apps/web/lib/supabase/server)", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = SUPABASE_ANON_KEY;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe("bearer-token path", () => {
+    it("builds a cookie-less client forwarding the Authorization header", async () => {
+      mockHeaders.mockResolvedValue(makeHeaderStore("Bearer tok-123"));
+      mockCreateServerClient.mockReturnValue(makeSsrClient());
+
+      await createClient();
+
+      expect(mockCreateServerClient).toHaveBeenCalledTimes(1);
+      const [url, key, options] = mockCreateServerClient.mock.calls[0];
+      expect(url).toBe(SUPABASE_URL);
+      expect(key).toBe(SUPABASE_ANON_KEY);
+      expect(options.global.headers).toEqual({ Authorization: "Bearer tok-123" });
+      // Cookie-less: getAll returns [] and setAll is a no-op
+      expect(options.cookies.getAll()).toEqual([]);
+      expect(() => options.cookies.setAll([])).not.toThrow();
+      // The web cookie store must not be touched on the bearer path
+      expect(mockCookies).not.toHaveBeenCalled();
+    });
+
+    it("defaults auth.getUser() to the bearer token when called with no argument", async () => {
+      mockHeaders.mockResolvedValue(makeHeaderStore("Bearer tok-123"));
+      const ssrClient = makeSsrClient();
+      const originalGetUser = ssrClient.auth.getUser;
+      mockCreateServerClient.mockReturnValue(ssrClient);
+
+      const client = await createClient();
+      await client.auth.getUser();
+
+      expect(originalGetUser).toHaveBeenCalledTimes(1);
+      expect(originalGetUser).toHaveBeenCalledWith("tok-123");
+    });
+
+    it("lets an explicit jwt argument win over the bearer token", async () => {
+      mockHeaders.mockResolvedValue(makeHeaderStore("Bearer tok-123"));
+      const ssrClient = makeSsrClient();
+      const originalGetUser = ssrClient.auth.getUser;
+      mockCreateServerClient.mockReturnValue(ssrClient);
+
+      const client = await createClient();
+      await client.auth.getUser("explicit-jwt");
+
+      expect(originalGetUser).toHaveBeenCalledWith("explicit-jwt");
+    });
+
+    it("matches the Bearer scheme case-insensitively", async () => {
+      mockHeaders.mockResolvedValue(makeHeaderStore("bearer lower-tok"));
+      const ssrClient = makeSsrClient();
+      const originalGetUser = ssrClient.auth.getUser;
+      mockCreateServerClient.mockReturnValue(ssrClient);
+
+      const client = await createClient();
+      await client.auth.getUser();
+
+      const [, , options] = mockCreateServerClient.mock.calls[0];
+      expect(options.global.headers).toEqual({ Authorization: "bearer lower-tok" });
+      expect(originalGetUser).toHaveBeenCalledWith("lower-tok");
+      expect(mockCookies).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cookie path", () => {
+    it("uses the cookie store when there is no Authorization header", async () => {
+      mockHeaders.mockResolvedValue(makeHeaderStore(null));
+      const cookieStore = makeCookieStore();
+      mockCookies.mockResolvedValue(cookieStore);
+      mockCreateServerClient.mockReturnValue(makeSsrClient());
+
+      await createClient();
+
+      expect(mockCookies).toHaveBeenCalledTimes(1);
+      const [url, key, options] = mockCreateServerClient.mock.calls[0];
+      expect(url).toBe(SUPABASE_URL);
+      expect(key).toBe(SUPABASE_ANON_KEY);
+      // No forwarded Authorization header on the cookie path
+      expect(options.global).toBeUndefined();
+      // getAll delegates to the Next.js cookie store
+      expect(options.cookies.getAll()).toEqual([{ name: "sb-token", value: "cookie-value" }]);
+      expect(cookieStore.getAll).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses the cookie path when the Authorization header is not a Bearer scheme", async () => {
+      mockHeaders.mockResolvedValue(makeHeaderStore("Basic dXNlcjpwYXNz"));
+      mockCookies.mockResolvedValue(makeCookieStore());
+      mockCreateServerClient.mockReturnValue(makeSsrClient());
+
+      await createClient();
+
+      const [, , options] = mockCreateServerClient.mock.calls[0];
+      expect(options.global).toBeUndefined();
+      expect(mockCookies).toHaveBeenCalledTimes(1);
+    });
+
+    it("setAll writes each cookie to the store", async () => {
+      mockHeaders.mockResolvedValue(makeHeaderStore(null));
+      const cookieStore = makeCookieStore();
+      mockCookies.mockResolvedValue(cookieStore);
+      mockCreateServerClient.mockReturnValue(makeSsrClient());
+
+      await createClient();
+      const [, , options] = mockCreateServerClient.mock.calls[0];
+
+      options.cookies.setAll([
+        { name: "a", value: "1", options: { path: "/" } },
+        { name: "b", value: "2", options: { path: "/" } },
+      ]);
+
+      expect(cookieStore.set).toHaveBeenCalledTimes(2);
+      expect(cookieStore.set).toHaveBeenNthCalledWith(1, "a", "1", { path: "/" });
+      expect(cookieStore.set).toHaveBeenNthCalledWith(2, "b", "2", { path: "/" });
+    });
+
+    it("setAll swallows errors thrown by the cookie store (Server Component context)", async () => {
+      mockHeaders.mockResolvedValue(makeHeaderStore(null));
+      const cookieStore = makeCookieStore();
+      cookieStore.set.mockImplementation(() => {
+        throw new Error("Cookies can only be modified in a Server Action");
+      });
+      mockCookies.mockResolvedValue(cookieStore);
+      mockCreateServerClient.mockReturnValue(makeSsrClient());
+
+      await createClient();
+      const [, , options] = mockCreateServerClient.mock.calls[0];
+
+      expect(() =>
+        options.cookies.setAll([{ name: "a", value: "1", options: {} }])
+      ).not.toThrow();
+    });
+  });
+});

--- a/apps/web/components/predictions/DriverSelect.tsx
+++ b/apps/web/components/predictions/DriverSelect.tsx
@@ -4,8 +4,9 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { ChevronDown, X } from "lucide-react";
 import type { Driver } from "@f1/shared/types";
 import { useLanguage } from "@/components/providers/LanguageProvider";
+import type { MatchStatus } from "@f1/shared/lib/prediction-status";
 
-export type MatchStatus = "exact" | "close" | "miss" | null;
+export type { MatchStatus };
 
 interface DriverSelectProps {
   label: string;

--- a/apps/web/components/predictions/RacePredictionContent.tsx
+++ b/apps/web/components/predictions/RacePredictionContent.tsx
@@ -43,7 +43,8 @@ import {
   type RaceFieldPoints,
   type SprintFieldPoints,
 } from "@f1/shared/lib/scoring";
-import { DriverSelect, type MatchStatus } from "./DriverSelect";
+import { proximityStatus, type MatchStatus } from "@f1/shared/lib/prediction-status";
+import { DriverSelect } from "./DriverSelect";
 import { useLanguage } from "@/components/providers/LanguageProvider";
 
 type TabMode = "race" | "sprint" | "champion";
@@ -62,36 +63,6 @@ interface SprintMatchStatuses {
   sprintWinner: MatchStatus;
   restOfTop8: MatchStatus[];
   fastestLap: MatchStatus;
-}
-
-/**
- * Driver-based ±1 proximity status, matching the 3/1/0 scoring in lib/scoring.ts.
- * Builds a Map<driverNumber, position> from the ordered result array (positions
- * 0..count-1) plus an optional boundary driver at index `count`, then returns the
- * status for the predicted driver at slot `slotIndex`:
- *   exact → same position; close → off by ±1; miss → otherwise.
- */
-function proximityStatus(
-  predicted: Driver | null,
-  resultDrivers: Driver[],
-  boundaryDriver: Driver | null,
-  count: number,
-  slotIndex: number
-): MatchStatus {
-  if (!predicted) return null;
-  const driverToPos = new Map<number, number>();
-  for (let i = 0; i < count; i++) {
-    const d = resultDrivers[i];
-    if (d && !driverToPos.has(d.driverNumber)) driverToPos.set(d.driverNumber, i);
-  }
-  if (boundaryDriver && !driverToPos.has(boundaryDriver.driverNumber)) {
-    driverToPos.set(boundaryDriver.driverNumber, count);
-  }
-  if (!driverToPos.has(predicted.driverNumber)) return "miss";
-  const delta = Math.abs(driverToPos.get(predicted.driverNumber)! - slotIndex);
-  if (delta === 0) return "exact";
-  if (delta === 1) return "close";
-  return "miss";
 }
 
 interface RacePredictionContentProps {

--- a/apps/web/lib/supabase/server.ts
+++ b/apps/web/lib/supabase/server.ts
@@ -1,7 +1,41 @@
 import { createServerClient } from "@supabase/ssr";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 
 export async function createClient() {
+  // The mobile app (Expo) has no cookies — it sends the Supabase access token
+  // as `Authorization: Bearer <token>`. When present, build a cookie-less
+  // client that forwards the JWT to PostgREST (RLS runs as the caller) and
+  // wrap auth.getUser() to validate that token against Supabase Auth, so
+  // route handlers work unchanged. Cookies remain the web path below.
+  const headerStore = await headers();
+  const authHeader = headerStore.get("authorization");
+  const bearerMatch = authHeader?.match(/^Bearer (.+)$/i);
+
+  if (bearerMatch) {
+    const token = bearerMatch[1];
+
+    const client = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll: () => [],
+          setAll: () => {},
+        },
+        global: {
+          headers: { Authorization: authHeader! },
+        },
+      }
+    );
+
+    // No cookie session exists, so getUser() with no argument would fail.
+    // Default it to the bearer token; explicit jwt arguments still win.
+    const originalGetUser = client.auth.getUser.bind(client.auth);
+    client.auth.getUser = (jwt?: string) => originalGetUser(jwt ?? token);
+
+    return client;
+  }
+
   const cookieStore = await cookies();
 
   return createServerClient(

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -61,7 +61,11 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
+  // /api is excluded: route handlers guard themselves (getUser -> 401 JSON).
+  // Redirecting API requests to the /login page breaks non-cookie clients —
+  // the mobile app authenticates with an Authorization: Bearer header and
+  // its fetch would silently follow the redirect into HTML.
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };

--- a/docs/mobile-migration/decisions.md
+++ b/docs/mobile-migration/decisions.md
@@ -2,6 +2,34 @@
 
 Running record of decisions made after the initial plan. Newest first.
 
+## 2026-07-10 — Bearer-token auth for mobile → Next.js API (Phase 3)
+
+**Decision:** The web API's `createClient()` (`apps/web/lib/supabase/server.ts`) now accepts
+`Authorization: Bearer <supabase access token>` in addition to SSR cookies. Mobile sends its
+AsyncStorage session token via `apps/mobile/src/lib/api.ts` (`apiFetch`, base URL from
+`EXPO_PUBLIC_API_URL`); web keeps cookies unchanged.
+
+**Why:** Locked decision #3 routes privileged writes through the Next.js API, but those routes
+authenticated only via `@supabase/ssr` cookies — a mobile app has no cookie jar, so every
+mobile submit would 401. Bearer support is a small backwards-compatible change that keeps all
+validation/driver-mapping logic in one place; the alternative (direct RLS writes from mobile)
+would duplicate it. On the bearer path the client forwards the JWT to PostgREST (RLS runs as
+the caller) and `auth.getUser()` is wrapped to validate the token, so route handlers stay
+unchanged.
+
+**Also this iteration:** Phase 3 split — race-tab prediction screen only first (validates the
+risky touch UI); sprint tab, champion tab, results-comparison display, leaderboard and
+standings follow in later iterations. Shared extractions: `fetchUserRacePredictions`
+(`packages/shared/lib/predictions.ts`) and `proximityStatus`/`MatchStatus`
+(`packages/shared/lib/prediction-status.ts`), both now consumed by web too (component level).
+
+## 2026-07-10 — Sign in with Apple deferred out of Phase 2
+
+**Decision:** Phase 2 shipped email/password + Google OAuth only (PR #84). Sign in with Apple
+waits until the paid Apple Developer account is purchased (tail of Phase 2 per the plan's
+cost-free path, at latest before Phase 5 submission — Apple Guideline 4.8 makes it mandatory
+once Google login ships on iOS).
+
 ## 2026-07-08 — Expo SDK 54, not 57 (Phase 1)
 
 **Decision:** `apps/mobile` targets **Expo SDK 54** (RN 0.81, React 19.1) instead of SDK 57.

--- a/packages/shared/lib/prediction-status.ts
+++ b/packages/shared/lib/prediction-status.ts
@@ -1,0 +1,34 @@
+import type { Driver } from "../types";
+
+/** Per-slot prediction match status once a result is known. */
+export type MatchStatus = "exact" | "close" | "miss" | null;
+
+/**
+ * Driver-based ±1 proximity status, matching the 3/1/0 scoring in lib/scoring.ts.
+ * Builds a Map<driverNumber, position> from the ordered result array (positions
+ * 0..count-1) plus an optional boundary driver at index `count`, then returns the
+ * status for the predicted driver at slot `slotIndex`:
+ *   exact → same position; close → off by ±1; miss → otherwise.
+ */
+export function proximityStatus(
+  predicted: Driver | null,
+  resultDrivers: Driver[],
+  boundaryDriver: Driver | null,
+  count: number,
+  slotIndex: number
+): MatchStatus {
+  if (!predicted) return null;
+  const driverToPos = new Map<number, number>();
+  for (let i = 0; i < count; i++) {
+    const d = resultDrivers[i];
+    if (d && !driverToPos.has(d.driverNumber)) driverToPos.set(d.driverNumber, i);
+  }
+  if (boundaryDriver && !driverToPos.has(boundaryDriver.driverNumber)) {
+    driverToPos.set(boundaryDriver.driverNumber, count);
+  }
+  if (!driverToPos.has(predicted.driverNumber)) return "miss";
+  const delta = Math.abs(driverToPos.get(predicted.driverNumber)! - slotIndex);
+  if (delta === 0) return "exact";
+  if (delta === 1) return "close";
+  return "miss";
+}

--- a/packages/shared/lib/predictions.ts
+++ b/packages/shared/lib/predictions.ts
@@ -1,0 +1,122 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Driver, FullRacePrediction, PredictionStatus, Race } from "../types";
+import { fetchDrivers } from "./drivers";
+
+interface RacePredictionRow {
+  race_id: number;
+  status: PredictionStatus | null;
+  pole_position_driver_id: number | null;
+  qualifying_top_3: (number | null)[] | null;
+  top_10: (number | null)[] | null;
+  fastest_lap_driver_id: number | null;
+  fastest_pit_stop_driver_id: number | null;
+  driver_of_the_day_driver_id: number | null;
+  points_earned: number | null;
+}
+
+/**
+ * Fetches a user's race predictions for the current season and maps them to
+ * one `FullRacePrediction` per passed-in race (keyed by `meetingKey`), with a
+ * pending placeholder when the user has no stored prediction for a race.
+ *
+ * Resolves DB driver ids to full `Driver` objects via the season-scoped
+ * driver-number mapping. When `qualifying_top_3` is empty/null it falls back
+ * to the legacy single `pole_position_driver_id` column.
+ *
+ * The caller injects the Supabase client. Returns `[]` when there is no
+ * current season.
+ */
+export async function fetchUserRacePredictions(
+  supabase: SupabaseClient,
+  userId: string,
+  races: Race[]
+): Promise<FullRacePrediction[]> {
+  const { data: currentSeason } = await supabase
+    .from("seasons")
+    .select("id")
+    .eq("is_current", true)
+    .single();
+
+  const seasonId = currentSeason?.id;
+  if (!seasonId) return [];
+
+  // Mapping: DB driver ID -> driver number (season-scoped)
+  const { data: dbDrivers } = await supabase
+    .from("drivers")
+    .select("id, driver_number")
+    .eq("season_id", seasonId);
+
+  const driverIdToNumber = new Map<number, number>();
+  for (const d of dbDrivers ?? []) {
+    driverIdToNumber.set(d.id, d.driver_number);
+  }
+
+  // Mapping: DB race ID -> meeting key (season-scoped)
+  const { data: dbRaces } = await supabase
+    .from("races")
+    .select("id, meeting_key")
+    .eq("season_id", seasonId);
+
+  const raceIdToMeetingKey = new Map<number, number>();
+  for (const r of dbRaces ?? []) {
+    raceIdToMeetingKey.set(r.id, r.meeting_key);
+  }
+
+  // Full driver objects, matched by driver number
+  const allDrivers = await fetchDrivers(supabase);
+
+  function findDriver(dbDriverId: number | null): Driver | null {
+    if (!dbDriverId) return null;
+    const driverNumber = driverIdToNumber.get(dbDriverId);
+    if (driverNumber === undefined) return null;
+    return allDrivers.find((d) => d.driverNumber === driverNumber) ?? null;
+  }
+
+  // Race prediction rows for the target user
+  const { data: racePredRows } = await supabase
+    .from("race_predictions")
+    .select(
+      "race_id, status, pole_position_driver_id, qualifying_top_3, top_10, fastest_lap_driver_id, fastest_pit_stop_driver_id, driver_of_the_day_driver_id, points_earned"
+    )
+    .eq("user_id", userId);
+
+  const racePredByMeetingKey = new Map<number, RacePredictionRow>();
+  for (const row of (racePredRows ?? []) as RacePredictionRow[]) {
+    const meetingKey = raceIdToMeetingKey.get(row.race_id);
+    if (meetingKey !== undefined) {
+      racePredByMeetingKey.set(meetingKey, row);
+    }
+  }
+
+  // Build a 3-slot qualifying-top-3 (Driver | null)[] from the stored array,
+  // falling back to the legacy single pole column for not-yet-backfilled rows.
+  function buildQualifyingTop3(
+    qualifyingTop3Ids: (number | null)[] | null | undefined,
+    legacyPoleId: number | null | undefined
+  ): (Driver | null)[] {
+    const ids: (number | null)[] =
+      qualifyingTop3Ids && qualifyingTop3Ids.length > 0
+        ? qualifyingTop3Ids
+        : legacyPoleId != null
+          ? [legacyPoleId]
+          : [];
+    return Array.from({ length: 3 }, (_, i) => findDriver(ids[i] ?? null));
+  }
+
+  return races.map((race) => {
+    const row = racePredByMeetingKey.get(race.meetingKey);
+    const top10Ids: (number | null)[] = row?.top_10 ?? [];
+    return {
+      raceId: race.meetingKey,
+      userId,
+      status: row?.status ?? "pending",
+      qualifyingTop3: buildQualifyingTop3(row?.qualifying_top_3, row?.pole_position_driver_id),
+      raceWinner: findDriver(top10Ids[0] ?? null),
+      restOfTop10: Array.from({ length: 9 }, (_, i) => findDriver(top10Ids[i + 1] ?? null)),
+      fastestLap: findDriver(row?.fastest_lap_driver_id ?? null),
+      fastestPitStop: findDriver(row?.fastest_pit_stop_driver_id ?? null),
+      driverOfTheDay: findDriver(row?.driver_of_the_day_driver_id ?? null),
+      pointsEarned: row?.points_earned ?? null,
+    };
+  });
+}

--- a/packages/shared/messages/en.ts
+++ b/packages/shared/messages/en.ts
@@ -360,6 +360,13 @@ const en = {
     championPrediction: "Championship prediction",
     predictionDeadline: "Prediction deadline",
     predictionsClosed: "Predictions closed",
+    // Mobile driver picker & data states
+    clearSelection: "Clear selection",
+    alreadySelected: "Already selected",
+    loadError: "Something went wrong while loading.",
+    retry: "Retry",
+    submitError: "Failed to submit prediction. Please try again.",
+    resetError: "Failed to reset prediction. Please try again.",
   },
 
   // ── Achievements page ───────────────────────────────────────────────────

--- a/packages/shared/messages/es.ts
+++ b/packages/shared/messages/es.ts
@@ -353,6 +353,13 @@ const es: Messages = {
     championPrediction: "Predicción de campeonato",
     predictionDeadline: "Plazo de predicción",
     predictionsClosed: "Predicciones cerradas",
+    // Selector de pilotos móvil y estados de datos
+    clearSelection: "Quitar selección",
+    alreadySelected: "Ya seleccionado",
+    loadError: "Algo salió mal al cargar.",
+    retry: "Reintentar",
+    submitError: "No se pudo enviar la predicción. Inténtalo de nuevo.",
+    resetError: "No se pudo reiniciar la predicción. Inténtalo de nuevo.",
   },
 
   // ── Achievements page ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Phase 3 (iteration 1) of the mobile migration: the race prediction screen — the highest-risk touch UI, built first to validate that predicting on a phone feels good. Verified on physical iPhone (Expo Go) and Android emulator against the live database.

### Shared (`@f1/shared`)
- `lib/predictions.ts` — `fetchUserRacePredictions(supabase, userId, races)`: assembles `FullRacePrediction[]` (extracted from the web page's inline logic, incl. the legacy pole-column fallback)
- `lib/prediction-status.ts` — `proximityStatus` + `MatchStatus` moved out of the web component; web now imports them from shared

### Web API — Bearer-token auth for mobile
- `lib/supabase/server.ts`: `createClient()` now also accepts `Authorization: Bearer <access token>` (cookie path unchanged). PostgREST runs under the caller's JWT (RLS as the user); `auth.getUser()` validates the token, so all route handlers work unchanged.
- `proxy.ts`: `/api` excluded from the auth proxy matcher — routes guard themselves (`getUser()` → 401 JSON). Previously the proxy 307-redirected cookie-less API requests to `/login`, so mobile submits never reached the handler.

### Mobile (`apps/mobile`)
- `(app)/race-prediction` screen: round selector, live deadline countdown, quali top-3 + winner + P2–P10 + specials via a bottom-sheet driver picker (duplicate-blocking matches web semantics), submit/update/reset with confirmation modals, pull-to-refresh, status + points-earned footer
- `lib/api.ts` — authenticated fetch helper (`EXPO_PUBLIC_API_URL` + Bearer header); rejects non-JSON responses so a redirect can never masquerade as success
- OAuth `auth/callback` route so deep links no longer hit Unmatched Route
- Home screen entry card; 6 new `predictionsPage.*` keys (en + es)

### Deferred to next iterations
Sprint tab, champion tab, results-comparison display, leaderboard + standings.

## Test plan
- [x] `npm run typecheck` (web + mobile) — zero errors
- [x] `npm test` — 24 suites, 357 tests (34 new; new shared libs at 100% lines)
- [x] `npm run lint` — zero errors; translation parity 490/490
- [x] `npx expo export --platform android` bundles
- [x] Manual: Google OAuth + full predict/submit/update flow on iOS (Expo Go, physical) and Android emulator, rows verified in the database and cross-checked on the web app