### PR TITLE
feat: mobile sprint/champion prediction tabs + results comparison (Phase 3)

### DIFF
--- a/apps/mobile/src/app/(app)/race-prediction.tsx
+++ b/apps/mobile/src/app/(app)/race-prediction.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -9,18 +9,50 @@ import {
   Text,
   View,
 } from "react-native";
+import { fetchChampionPredictionData } from "@f1/shared/lib/champion-predictions";
 import { fetchDrivers } from "@f1/shared/lib/drivers";
-import { fetchUserRacePredictions } from "@f1/shared/lib/predictions";
+import {
+  computeRaceMatchStatuses,
+  computeSprintMatchStatuses,
+} from "@f1/shared/lib/prediction-status";
+import {
+  fetchUserRacePredictions,
+  fetchUserSprintPredictions,
+} from "@f1/shared/lib/predictions";
+import {
+  countryCodeToFlag,
+  getChampionPredictionPhase,
+  getRaceStatus,
+} from "@f1/shared/lib/race-utils";
 import { fetchRaces } from "@f1/shared/lib/races";
-import { countryCodeToFlag, getRaceStatus } from "@f1/shared/lib/race-utils";
-import type { Driver, FullRacePrediction } from "@f1/shared/types";
+import { fetchRaceResults, fetchSprintResults } from "@f1/shared/lib/results";
+import {
+  computeRaceFieldPoints,
+  computeSprintFieldPoints,
+  type RaceFieldPoints,
+  type SprintFieldPoints,
+} from "@f1/shared/lib/scoring";
+import { fetchTeamsWithDrivers } from "@f1/shared/lib/teams";
+import type {
+  ChampionPrediction,
+  Driver,
+  FullRacePrediction,
+  PredictionStatus,
+  SprintPrediction,
+  TeamBestDriverPrediction,
+} from "@f1/shared/types";
 
+import { BonusBadges, type BonusBadge } from "@/components/predictions/BonusBadges";
+import { ChampionForm, type ChampionDriverSlot } from "@/components/predictions/ChampionForm";
 import { ConfirmModal } from "@/components/predictions/ConfirmModal";
 import { CountdownBar } from "@/components/predictions/CountdownBar";
 import { DriverPickerModal } from "@/components/predictions/DriverPickerModal";
 import { DriverSlot } from "@/components/predictions/DriverSlot";
+import { PredictionTabs, type PredictionTab } from "@/components/predictions/PredictionTabs";
+import { RaceResultsPanel, SprintResultsPanel } from "@/components/predictions/ResultsPanel";
 import { RoundSelectorModal } from "@/components/predictions/RoundSelectorModal";
 import { PredictionStatusBadge, RaceStatusBadge } from "@/components/predictions/StatusBadges";
+import { TeamPickerModal } from "@/components/predictions/TeamPickerModal";
 import { apiFetch } from "@/lib/api";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/providers/AuthProvider";
@@ -28,12 +60,20 @@ import { useLanguage } from "@/providers/LanguageProvider";
 
 /** Which prediction slot the driver picker is currently editing. */
 type SlotTarget =
+  // Race tab
   | { kind: "qualifying"; index: number }
   | { kind: "winner" }
   | { kind: "rest"; index: number }
   | { kind: "fastestLap" }
   | { kind: "fastestPitStop" }
-  | { kind: "driverOfTheDay" };
+  | { kind: "driverOfTheDay" }
+  // Sprint tab
+  | { kind: "sprintQualifying"; index: number }
+  | { kind: "sprintWinner" }
+  | { kind: "sprintRest"; index: number }
+  | { kind: "sprintFastestLap" }
+  // Champion tab
+  | { kind: "champion"; slot: ChampionDriverSlot };
 
 export default function RacePredictionScreen() {
   const { t, language } = useLanguage();
@@ -60,6 +100,29 @@ export default function RacePredictionScreen() {
     queryFn: () => fetchUserRacePredictions(supabase, userId!, races),
     enabled: !!userId && races.length > 0,
   });
+  const sprintPredictionsQuery = useQuery({
+    queryKey: ["sprintPredictions", userId],
+    queryFn: () => fetchUserSprintPredictions(supabase, userId!, races),
+    enabled: !!userId && races.length > 0,
+  });
+  const teamsQuery = useQuery({
+    queryKey: ["teamsWithDrivers"],
+    queryFn: () => fetchTeamsWithDrivers(supabase),
+  });
+  const teamsWithDrivers = teamsQuery.data;
+  const championQuery = useQuery({
+    queryKey: ["championPrediction", userId],
+    queryFn: () => fetchChampionPredictionData(supabase, userId!, teamsWithDrivers!),
+    enabled: !!userId && !!teamsWithDrivers,
+  });
+  const raceResultsQuery = useQuery({
+    queryKey: ["raceResults"],
+    queryFn: () => fetchRaceResults(supabase),
+  });
+  const sprintResultsQuery = useQuery({
+    queryKey: ["sprintResults"],
+    queryFn: () => fetchSprintResults(supabase),
+  });
 
   /* ── Local edit state (mirrors the web: edits live locally until submit) ── */
 
@@ -68,7 +131,28 @@ export default function RacePredictionScreen() {
     if (predictionsQuery.data) setPredictions(predictionsQuery.data);
   }, [predictionsQuery.data]);
 
-  /* ── Round selection (default: first race whose weekend hasn't ended) ── */
+  const [sprintPreds, setSprintPreds] = useState<SprintPrediction[] | null>(null);
+  useEffect(() => {
+    if (sprintPredictionsQuery.data) setSprintPreds(sprintPredictionsQuery.data);
+  }, [sprintPredictionsQuery.data]);
+
+  const [champPred, setChampPred] = useState<ChampionPrediction | null>(null);
+  const [teamBestPreds, setTeamBestPreds] = useState<TeamBestDriverPrediction[] | null>(null);
+  // Last successfully saved champion state, for changed-field detection on updates.
+  const savedChampPred = useRef<ChampionPrediction | null>(null);
+  const savedTeamBestPreds = useRef<TeamBestDriverPrediction[] | null>(null);
+  useEffect(() => {
+    if (championQuery.data) {
+      setChampPred(championQuery.data.championPrediction);
+      setTeamBestPreds(championQuery.data.teamBestDriverPredictions);
+      savedChampPred.current = championQuery.data.championPrediction;
+      savedTeamBestPreds.current = championQuery.data.teamBestDriverPredictions;
+    }
+  }, [championQuery.data]);
+
+  /* ── Tab + round selection (default: first race whose weekend hasn't ended) ── */
+
+  const [tab, setTab] = useState<PredictionTab>("race");
 
   const defaultRaceIndex = useMemo(() => {
     const now = Date.now();
@@ -78,16 +162,25 @@ export default function RacePredictionScreen() {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const raceIndex = selectedIndex ?? defaultRaceIndex;
 
+  function selectRound(index: number) {
+    setSelectedIndex(index);
+    // Leaving a sprint tab for a round without a sprint falls back to Race.
+    if (tab === "sprint" && !races[index]?.hasSprint) setTab("race");
+  }
+
   const [roundPickerOpen, setRoundPickerOpen] = useState(false);
   const [pickerTarget, setPickerTarget] = useState<SlotTarget | null>(null);
+  const [teamPickerOpen, setTeamPickerOpen] = useState(false);
   const [showResetModal, setShowResetModal] = useState(false);
   const [showSubmitModal, setShowSubmitModal] = useState(false);
+  const [showResults, setShowResults] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
 
   // Deadlines that expired while the screen was open (countdown hit zero).
-  const [expiredMeetingKeys, setExpiredMeetingKeys] = useState<Set<number>>(new Set());
+  const [expiredRaceKeys, setExpiredRaceKeys] = useState<Set<number>>(new Set());
+  const [expiredSprintKeys, setExpiredSprintKeys] = useState<Set<number>>(new Set());
 
   /* ── Loading / error states ───────────────────────────────────────── */
 
@@ -140,17 +233,55 @@ export default function RacePredictionScreen() {
   const drivers = driversQuery.data ?? [];
   const currentPrediction =
     (predictions ?? []).find((p) => p.raceId === currentRace.meetingKey) ?? null;
+  const currentSprintPred =
+    (sprintPreds ?? []).find((p) => p.raceId === currentRace.meetingKey) ?? null;
+  const currentResult = raceResultsQuery.data?.[currentRace.meetingKey];
+  const currentSprintResult = sprintResultsQuery.data?.[currentRace.meetingKey];
 
-  const deadlinePassed =
-    new Date(currentRace.dateEnd).getTime() <= Date.now() ||
-    expiredMeetingKeys.has(currentRace.meetingKey);
-  const isEditable = currentPrediction?.status !== "scored" && !deadlinePassed;
+  // Separate deadlines: sprint uses sprintDateEnd, race uses dateEnd.
+  const raceDeadline = currentRace.dateEnd;
+  const sprintDeadline = currentRace.sprintDateEnd ?? currentRace.dateEnd;
+  const raceDeadlinePassed =
+    new Date(raceDeadline).getTime() <= Date.now() ||
+    expiredRaceKeys.has(currentRace.meetingKey);
+  const sprintDeadlinePassed =
+    new Date(sprintDeadline).getTime() <= Date.now() ||
+    expiredSprintKeys.has(currentRace.meetingKey);
 
-  const hasEdits =
-    !!currentPrediction &&
-    (currentPrediction.qualifyingTop3.some((d) => d !== null) ||
-      currentPrediction.raceWinner !== null ||
-      currentPrediction.restOfTop10.some((d) => d !== null));
+  const championPhase = getChampionPredictionPhase(races);
+  const isChampionTab = tab === "champion";
+  const seasonStarted = championPhase !== "full";
+  const champNeedsAttention =
+    championPhase === "full" && (champPred ? champPred.status !== "scored" : false);
+  const sprintNeedsAttention =
+    !sprintDeadlinePassed && currentSprintPred?.status !== "scored";
+
+  const activeDeadline = tab === "sprint" ? sprintDeadline : raceDeadline;
+  const deadlinePassed = tab === "sprint" ? sprintDeadlinePassed : raceDeadlinePassed;
+
+  const isEditable = isChampionTab
+    ? !!champPred && champPred.status !== "scored" && championPhase !== "closed"
+    : tab === "sprint"
+      ? currentSprintPred?.status !== "scored" && !sprintDeadlinePassed
+      : currentPrediction?.status !== "scored" && !raceDeadlinePassed;
+
+  const hasEdits = isChampionTab
+    ? !!champPred &&
+      (champPred.wdcWinner !== null ||
+        champPred.wccWinner !== null ||
+        champPred.mostDnfsDriver !== null ||
+        champPred.mostPodiumsDriver !== null ||
+        champPred.mostWinsDriver !== null ||
+        (teamBestPreds ?? []).some((p) => p.driverNumber !== null))
+    : tab === "sprint"
+      ? !!currentSprintPred &&
+        (currentSprintPred.qualifyingTop3.some((d) => d !== null) ||
+          currentSprintPred.sprintWinner !== null ||
+          currentSprintPred.restOfTop8.some((d) => d !== null))
+      : !!currentPrediction &&
+        (currentPrediction.qualifyingTop3.some((d) => d !== null) ||
+          currentPrediction.raceWinner !== null ||
+          currentPrediction.restOfTop10.some((d) => d !== null));
 
   const formatDate = (dateStr: string) =>
     new Date(dateStr).toLocaleDateString(language === "es" ? "es-ES" : "en-US", {
@@ -158,60 +289,211 @@ export default function RacePredictionScreen() {
       day: "numeric",
     });
 
-  /* ── Slot helpers (shared driver pool for winner + rest of top 10) ── */
+  /* ── Results comparison (match statuses + per-field points) ───────── */
+
+  const raceMatchStatuses =
+    currentResult && currentPrediction
+      ? computeRaceMatchStatuses(currentPrediction, currentResult)
+      : null;
+  const raceFieldPoints: RaceFieldPoints | null =
+    currentResult && currentPrediction && currentPrediction.status === "scored"
+      ? computeRaceFieldPoints({
+          predTop10: [
+            currentPrediction.raceWinner?.driverNumber ?? null,
+            ...currentPrediction.restOfTop10.map((d) => d?.driverNumber ?? null),
+          ],
+          predQualifyingTop3: currentPrediction.qualifyingTop3.map(
+            (d) => d?.driverNumber ?? null
+          ),
+          predFastestLap: currentPrediction.fastestLap?.driverNumber ?? null,
+          predFastestPitStop: currentPrediction.fastestPitStop?.driverNumber ?? null,
+          predDriverOfTheDay: currentPrediction.driverOfTheDay?.driverNumber ?? null,
+          resultTop10: currentResult.top10.map((d) => d.driverNumber),
+          resultP11: currentResult.p11?.driverNumber ?? null,
+          resultQualifyingTop3: currentResult.qualifyingTop3.map((d) => d.driverNumber),
+          resultQualifyingP4: currentResult.qualifyingP4?.driverNumber ?? null,
+          resultFastestLap: currentResult.fastestLap.driverNumber,
+          resultFastestPitStop: currentResult.fastestPitStop?.driverNumber ?? -1,
+          resultDriverOfTheDay: currentResult.driverOfTheDay?.driverNumber ?? null,
+        })
+      : null;
+
+  const sprintMatchStatuses =
+    currentSprintResult && currentSprintPred
+      ? computeSprintMatchStatuses(currentSprintPred, currentSprintResult)
+      : null;
+  const sprintFieldPoints: SprintFieldPoints | null =
+    currentSprintResult && currentSprintPred && currentSprintPred.status === "scored"
+      ? computeSprintFieldPoints({
+          predTop8: [
+            currentSprintPred.sprintWinner?.driverNumber ?? null,
+            ...currentSprintPred.restOfTop8.map((d) => d?.driverNumber ?? null),
+          ],
+          predQualifyingTop3: currentSprintPred.qualifyingTop3.map(
+            (d) => d?.driverNumber ?? null
+          ),
+          predFastestLap: currentSprintPred.fastestLap?.driverNumber ?? null,
+          resultTop8: currentSprintResult.top8.map((d) => d.driverNumber),
+          resultP9: currentSprintResult.p9?.driverNumber ?? null,
+          resultQualifyingTop3: currentSprintResult.qualifyingTop3.map((d) => d.driverNumber),
+          resultQualifyingP4: currentSprintResult.qualifyingP4?.driverNumber ?? null,
+          resultFastestLap: currentSprintResult.fastestLap.driverNumber,
+        })
+      : null;
+
+  const raceBonusBadges: BonusBadge[] = raceFieldPoints
+    ? buildBonusBadges([
+        {
+          perfect: raceFieldPoints.perfectPodiumBonus,
+          match: raceFieldPoints.matchPodiumBonus,
+          perfectLabel: t.predictionsPage.perfectPodiumBonus,
+          matchLabel: t.predictionsPage.matchPodiumBonus,
+        },
+        {
+          perfect: raceFieldPoints.perfectTop10Bonus,
+          match: raceFieldPoints.matchTop10Bonus,
+          perfectLabel: t.predictionsPage.perfectTop10Bonus,
+          matchLabel: t.predictionsPage.matchTop10Bonus,
+        },
+        {
+          perfect: raceFieldPoints.perfectQualifyingBonus,
+          match: raceFieldPoints.matchQualifyingBonus,
+          perfectLabel: t.predictionsPage.perfectQualifyingBonus,
+          matchLabel: t.predictionsPage.matchQualifyingBonus,
+        },
+      ])
+    : [];
+
+  const sprintBonusBadges: BonusBadge[] = sprintFieldPoints
+    ? buildBonusBadges([
+        {
+          perfect: sprintFieldPoints.perfectPodiumBonus,
+          match: sprintFieldPoints.matchPodiumBonus,
+          perfectLabel: t.predictionsPage.perfectPodiumBonus,
+          matchLabel: t.predictionsPage.matchPodiumBonus,
+        },
+        {
+          perfect: sprintFieldPoints.perfectTop8Bonus,
+          match: sprintFieldPoints.matchTop8Bonus,
+          perfectLabel: t.predictionsPage.perfectTop8Bonus,
+          matchLabel: t.predictionsPage.matchTop8Bonus,
+        },
+        {
+          perfect: sprintFieldPoints.perfectQualifyingBonus,
+          match: sprintFieldPoints.matchQualifyingBonus,
+          perfectLabel: t.predictionsPage.perfectQualifyingBonus,
+          matchLabel: t.predictionsPage.matchQualifyingBonus,
+        },
+      ])
+    : [];
+
+  const activeResultExists = !isChampionTab && !!(tab === "sprint" ? currentSprintResult : currentResult);
+
+  /* ── Slot helpers ─────────────────────────────────────────────────── */
 
   function getSlotLabel(slot: SlotTarget): string {
     switch (slot.kind) {
       case "qualifying":
+      case "sprintQualifying":
         return `Q${slot.index + 1}`;
       case "winner":
         return t.predictionsPage.raceWinner;
+      case "sprintWinner":
+        return t.predictionsPage.sprintWinnerP1;
       case "rest":
+      case "sprintRest":
         return `P${slot.index + 2}`;
       case "fastestLap":
+      case "sprintFastestLap":
         return t.predictionsPage.fastestLap;
       case "fastestPitStop":
         return t.predictionsPage.fastestPitStop;
       case "driverOfTheDay":
         return t.predictionsPage.driverOfTheDay;
+      case "champion":
+        switch (slot.slot) {
+          case "wdc":
+            return t.predictionsPage.wdc;
+          case "mostWins":
+            return t.predictionsPage.mostWins;
+          case "mostPodiums":
+            return t.predictionsPage.mostPodiums;
+          case "mostDnfs":
+            return t.predictionsPage.mostDnfs;
+        }
     }
   }
 
-  function getSlotValue(pred: FullRacePrediction, slot: SlotTarget): Driver | null {
+  function getSlotValue(slot: SlotTarget): Driver | null {
     switch (slot.kind) {
       case "qualifying":
-        return pred.qualifyingTop3[slot.index];
+        return currentPrediction?.qualifyingTop3[slot.index] ?? null;
       case "winner":
-        return pred.raceWinner;
+        return currentPrediction?.raceWinner ?? null;
       case "rest":
-        return pred.restOfTop10[slot.index];
+        return currentPrediction?.restOfTop10[slot.index] ?? null;
       case "fastestLap":
-        return pred.fastestLap;
+        return currentPrediction?.fastestLap ?? null;
       case "fastestPitStop":
-        return pred.fastestPitStop;
+        return currentPrediction?.fastestPitStop ?? null;
       case "driverOfTheDay":
-        return pred.driverOfTheDay;
+        return currentPrediction?.driverOfTheDay ?? null;
+      case "sprintQualifying":
+        return currentSprintPred?.qualifyingTop3[slot.index] ?? null;
+      case "sprintWinner":
+        return currentSprintPred?.sprintWinner ?? null;
+      case "sprintRest":
+        return currentSprintPred?.restOfTop8[slot.index] ?? null;
+      case "sprintFastestLap":
+        return currentSprintPred?.fastestLap ?? null;
+      case "champion":
+        switch (slot.slot) {
+          case "wdc":
+            return champPred?.wdcWinner ?? null;
+          case "mostWins":
+            return champPred?.mostWinsDriver ?? null;
+          case "mostPodiums":
+            return champPred?.mostPodiumsDriver ?? null;
+          case "mostDnfs":
+            return champPred?.mostDnfsDriver ?? null;
+        }
     }
   }
 
-  function getDisabledForSlot(pred: FullRacePrediction, slot: SlotTarget): Driver[] {
-    if (slot.kind === "qualifying") {
-      return pred.qualifyingTop3.filter(
+  function getDisabledForSlot(slot: SlotTarget): Driver[] {
+    if (slot.kind === "qualifying" && currentPrediction) {
+      return currentPrediction.qualifyingTop3.filter(
         (d, i): d is Driver => d !== null && i !== slot.index
       );
     }
-    if (slot.kind === "winner") {
-      return pred.restOfTop10.filter((d): d is Driver => d !== null);
+    if (slot.kind === "sprintQualifying" && currentSprintPred) {
+      return currentSprintPred.qualifyingTop3.filter(
+        (d, i): d is Driver => d !== null && i !== slot.index
+      );
     }
-    if (slot.kind === "rest") {
+    if (slot.kind === "winner" && currentPrediction) {
+      return currentPrediction.restOfTop10.filter((d): d is Driver => d !== null);
+    }
+    if (slot.kind === "sprintWinner" && currentSprintPred) {
+      return currentSprintPred.restOfTop8.filter((d): d is Driver => d !== null);
+    }
+    if (slot.kind === "rest" && currentPrediction) {
       const used: Driver[] = [];
-      if (pred.raceWinner) used.push(pred.raceWinner);
-      pred.restOfTop10.forEach((d, i) => {
+      if (currentPrediction.raceWinner) used.push(currentPrediction.raceWinner);
+      currentPrediction.restOfTop10.forEach((d, i) => {
         if (d && i !== slot.index) used.push(d);
       });
       return used;
     }
-    return []; // specials may repeat drivers freely
+    if (slot.kind === "sprintRest" && currentSprintPred) {
+      const used: Driver[] = [];
+      if (currentSprintPred.sprintWinner) used.push(currentSprintPred.sprintWinner);
+      currentSprintPred.restOfTop8.forEach((d, i) => {
+        if (d && i !== slot.index) used.push(d);
+      });
+      return used;
+    }
+    return []; // specials + champion picks may repeat drivers freely
   }
 
   function updateCurrentPrediction(update: Partial<FullRacePrediction>) {
@@ -222,10 +504,18 @@ export default function RacePredictionScreen() {
     );
   }
 
+  function updateCurrentSprintPrediction(update: Partial<SprintPrediction>) {
+    setSprintPreds((prev) =>
+      prev
+        ? prev.map((p) => (p.raceId === currentRace.meetingKey ? { ...p, ...update } : p))
+        : prev
+    );
+  }
+
   function applySlot(slot: SlotTarget, driver: Driver | null) {
-    if (!currentPrediction) return;
     switch (slot.kind) {
       case "qualifying": {
+        if (!currentPrediction) return;
         const updated = [...currentPrediction.qualifyingTop3];
         updated[slot.index] = driver;
         updateCurrentPrediction({ qualifyingTop3: updated });
@@ -235,6 +525,7 @@ export default function RacePredictionScreen() {
         updateCurrentPrediction({ raceWinner: driver });
         break;
       case "rest": {
+        if (!currentPrediction) return;
         const updated = [...currentPrediction.restOfTop10];
         updated[slot.index] = driver;
         updateCurrentPrediction({ restOfTop10: updated });
@@ -249,32 +540,130 @@ export default function RacePredictionScreen() {
       case "driverOfTheDay":
         updateCurrentPrediction({ driverOfTheDay: driver });
         break;
+      case "sprintQualifying": {
+        if (!currentSprintPred) return;
+        const updated = [...currentSprintPred.qualifyingTop3];
+        updated[slot.index] = driver;
+        updateCurrentSprintPrediction({ qualifyingTop3: updated });
+        break;
+      }
+      case "sprintWinner":
+        updateCurrentSprintPrediction({ sprintWinner: driver });
+        break;
+      case "sprintRest": {
+        if (!currentSprintPred) return;
+        const updated = [...currentSprintPred.restOfTop8];
+        updated[slot.index] = driver;
+        updateCurrentSprintPrediction({ restOfTop8: updated });
+        break;
+      }
+      case "sprintFastestLap":
+        updateCurrentSprintPrediction({ fastestLap: driver });
+        break;
+      case "champion":
+        setChampPred((prev) => {
+          if (!prev) return prev;
+          switch (slot.slot) {
+            case "wdc":
+              return { ...prev, wdcWinner: driver };
+            case "mostWins":
+              return { ...prev, mostWinsDriver: driver };
+            case "mostPodiums":
+              return { ...prev, mostPodiumsDriver: driver };
+            case "mostDnfs":
+              return { ...prev, mostDnfsDriver: driver };
+          }
+        });
+        break;
     }
   }
 
+  /* ── Champion changed-field detection (for the half-points modal) ── */
+
+  const changedChampionFields: string[] = (() => {
+    if (!isChampionTab || !champPred || champPred.status !== "submitted") return [];
+    const saved = savedChampPred.current;
+    if (!saved) return [];
+    const fields: string[] = [];
+    if (champPred.wdcWinner?.driverNumber !== saved.wdcWinner?.driverNumber)
+      fields.push(t.predictionsPage.wdc);
+    if (champPred.wccWinner !== saved.wccWinner) fields.push(t.predictionsPage.wcc);
+    if (champPred.mostDnfsDriver?.driverNumber !== saved.mostDnfsDriver?.driverNumber)
+      fields.push(t.predictionsPage.mostDnfs);
+    if (champPred.mostPodiumsDriver?.driverNumber !== saved.mostPodiumsDriver?.driverNumber)
+      fields.push(t.predictionsPage.mostPodiums);
+    if (champPred.mostWinsDriver?.driverNumber !== saved.mostWinsDriver?.driverNumber)
+      fields.push(t.predictionsPage.mostWins);
+    for (const curr of teamBestPreds ?? []) {
+      const prev = savedTeamBestPreds.current?.find((p) => p.teamId === curr.teamId);
+      if (curr.driverNumber !== prev?.driverNumber)
+        fields.push(`${t.predictionsPage.teamBestDriver}: ${curr.teamName}`);
+    }
+    return fields;
+  })();
+
   /* ── Submit / reset ───────────────────────────────────────────────── */
 
-  async function invalidatePredictions() {
-    await queryClient.invalidateQueries({ queryKey: ["racePredictions", userId] });
+  async function invalidateActivePredictions() {
+    if (isChampionTab) {
+      await queryClient.invalidateQueries({ queryKey: ["championPrediction", userId] });
+    } else if (tab === "sprint") {
+      await queryClient.invalidateQueries({ queryKey: ["sprintPredictions", userId] });
+    } else {
+      await queryClient.invalidateQueries({ queryKey: ["racePredictions", userId] });
+    }
+  }
+
+  function buildSubmitPayload(): Record<string, unknown> | null {
+    if (isChampionTab) {
+      if (!champPred) return null;
+      return {
+        type: "champion",
+        wdcDriverNumber: champPred.wdcWinner?.driverNumber ?? null,
+        wccTeamName: champPred.wccWinner,
+        mostDnfsDriverNumber: champPred.mostDnfsDriver?.driverNumber ?? null,
+        mostPodiumsDriverNumber: champPred.mostPodiumsDriver?.driverNumber ?? null,
+        mostWinsDriverNumber: champPred.mostWinsDriver?.driverNumber ?? null,
+        teamBestDrivers: (teamBestPreds ?? [])
+          .filter((p) => p.driverNumber !== null)
+          .map((p) => ({ teamId: p.teamId, driverNumber: p.driverNumber! })),
+      };
+    }
+    if (tab === "sprint") {
+      if (!currentSprintPred) return null;
+      return {
+        type: "sprint",
+        raceId: currentRace.meetingKey,
+        qualifyingTop3: currentSprintPred.qualifyingTop3.map((d) => d?.driverNumber ?? null),
+        top8: [
+          currentSprintPred.sprintWinner?.driverNumber ?? null,
+          ...currentSprintPred.restOfTop8.map((d) => d?.driverNumber ?? null),
+        ],
+        fastestLapDriverNumber: currentSprintPred.fastestLap?.driverNumber ?? null,
+      };
+    }
+    if (!currentPrediction) return null;
+    return {
+      type: "race",
+      raceId: currentRace.meetingKey,
+      qualifyingTop3: currentPrediction.qualifyingTop3.map((d) => d?.driverNumber ?? null),
+      top10: [
+        currentPrediction.raceWinner?.driverNumber ?? null,
+        ...currentPrediction.restOfTop10.map((d) => d?.driverNumber ?? null),
+      ],
+      fastestLapDriverNumber: currentPrediction.fastestLap?.driverNumber ?? null,
+      fastestPitStopDriverNumber: currentPrediction.fastestPitStop?.driverNumber ?? null,
+      driverOfTheDayDriverNumber: currentPrediction.driverOfTheDay?.driverNumber ?? null,
+    };
   }
 
   async function handleSubmit() {
-    if (!currentPrediction || isSaving) return;
+    if (isSaving) return;
+    const payload = buildSubmitPayload();
+    if (!payload) return;
     setIsSaving(true);
     setErrorMessage(null);
     try {
-      const payload = {
-        type: "race",
-        raceId: currentRace.meetingKey,
-        qualifyingTop3: currentPrediction.qualifyingTop3.map((d) => d?.driverNumber ?? null),
-        top10: [
-          currentPrediction.raceWinner?.driverNumber ?? null,
-          ...currentPrediction.restOfTop10.map((d) => d?.driverNumber ?? null),
-        ],
-        fastestLapDriverNumber: currentPrediction.fastestLap?.driverNumber ?? null,
-        fastestPitStopDriverNumber: currentPrediction.fastestPitStop?.driverNumber ?? null,
-        driverOfTheDayDriverNumber: currentPrediction.driverOfTheDay?.driverNumber ?? null,
-      };
       const res = await apiFetch("/api/predictions/submit", {
         method: "POST",
         body: JSON.stringify(payload),
@@ -284,8 +673,20 @@ export default function RacePredictionScreen() {
         setErrorMessage(data?.error || t.predictionsPage.submitError);
         return;
       }
-      updateCurrentPrediction({ status: "submitted" });
-      await invalidatePredictions();
+      if (isChampionTab) {
+        setChampPred((prev) => {
+          if (!prev) return prev;
+          const next = { ...prev, status: "submitted" as PredictionStatus };
+          savedChampPred.current = next;
+          return next;
+        });
+        savedTeamBestPreds.current = (teamBestPreds ?? []).map((p) => ({ ...p }));
+      } else if (tab === "sprint") {
+        updateCurrentSprintPrediction({ status: "submitted" });
+      } else {
+        updateCurrentPrediction({ status: "submitted" });
+      }
+      await invalidateActivePredictions();
     } catch {
       setErrorMessage(t.predictionsPage.submitError);
     } finally {
@@ -294,29 +695,43 @@ export default function RacePredictionScreen() {
   }
 
   async function handleReset() {
-    if (isSaving) return;
+    if (isSaving || isChampionTab) return;
     setIsSaving(true);
     setErrorMessage(null);
     try {
+      const payload =
+        tab === "sprint"
+          ? { type: "sprint", raceId: currentRace.meetingKey }
+          : { type: "race", raceId: currentRace.meetingKey };
       const res = await apiFetch("/api/predictions/reset", {
         method: "POST",
-        body: JSON.stringify({ type: "race", raceId: currentRace.meetingKey }),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}) as { error?: string });
         setErrorMessage(data?.error || t.predictionsPage.resetError);
         return;
       }
-      updateCurrentPrediction({
-        qualifyingTop3: [null, null, null],
-        raceWinner: null,
-        restOfTop10: Array.from({ length: 9 }, () => null),
-        fastestLap: null,
-        fastestPitStop: null,
-        driverOfTheDay: null,
-        status: "pending",
-      });
-      await invalidatePredictions();
+      if (tab === "sprint") {
+        updateCurrentSprintPrediction({
+          qualifyingTop3: [null, null, null],
+          sprintWinner: null,
+          restOfTop8: Array.from({ length: 7 }, () => null),
+          fastestLap: null,
+          status: "pending",
+        });
+      } else {
+        updateCurrentPrediction({
+          qualifyingTop3: [null, null, null],
+          raceWinner: null,
+          restOfTop10: Array.from({ length: 9 }, () => null),
+          fastestLap: null,
+          fastestPitStop: null,
+          driverOfTheDay: null,
+          status: "pending",
+        });
+      }
+      await invalidateActivePredictions();
     } catch {
       setErrorMessage(t.predictionsPage.resetError);
     } finally {
@@ -331,6 +746,11 @@ export default function RacePredictionScreen() {
         racesQuery.refetch(),
         driversQuery.refetch(),
         predictionsQuery.refetch(),
+        sprintPredictionsQuery.refetch(),
+        teamsQuery.refetch(),
+        championQuery.refetch(),
+        raceResultsQuery.refetch(),
+        sprintResultsQuery.refetch(),
       ]);
     } finally {
       setRefreshing(false);
@@ -339,7 +759,12 @@ export default function RacePredictionScreen() {
 
   /* ── Submit button config (mirrors the web status → color mapping) ── */
 
-  const status = currentPrediction?.status ?? "pending";
+  const status: PredictionStatus = isChampionTab
+    ? (champPred?.status ?? "pending")
+    : tab === "sprint"
+      ? (currentSprintPred?.status ?? "pending")
+      : (currentPrediction?.status ?? "pending");
+
   const submitConfig =
     status === "scored"
       ? { className: "bg-f1-white/10", textClassName: "text-f1-white/40", label: t.predictionsPage.scored, disabled: true }
@@ -349,8 +774,39 @@ export default function RacePredictionScreen() {
           ? { className: "bg-f1-amber active:bg-f1-amber/80", textClassName: "text-black", label: t.predictionsPage.updatePrediction, disabled: false }
           : { className: "bg-f1-green active:bg-f1-green/80", textClassName: "text-black", label: t.predictionsPage.submitPrediction, disabled: false };
 
-  const pickerValue =
-    pickerTarget && currentPrediction ? getSlotValue(currentPrediction, pickerTarget) : null;
+  // Points shown in the actions bar: the combined weekend total on race/sprint
+  // tabs of a sprint round (so both tabs agree), champion total on champion.
+  const racePts = currentPrediction?.pointsEarned ?? null;
+  const sprintPts = currentSprintPred?.pointsEarned ?? null;
+  const weekendPts = currentRace.hasSprint
+    ? racePts !== null || sprintPts !== null
+      ? (racePts ?? 0) + (sprintPts ?? 0)
+      : null
+    : racePts;
+  const pointsEarned = isChampionTab ? (champPred?.pointsEarned ?? null) : weekendPts;
+
+  // Deadline handling for the actions bar: champion has no per-round deadline.
+  const actionsLocked = isChampionTab ? championPhase === "closed" : deadlinePassed;
+
+  // Update confirmation: race/sprint after a first submit; champion whenever
+  // updates would earn half points (season started).
+  const needsSubmitModal = isChampionTab ? seasonStarted : status === "submitted";
+
+  const submitModalBody = isChampionTab
+    ? champPred?.status !== "submitted"
+      ? t.predictionsPage.championHalfPointsFirstNote
+      : changedChampionFields.length > 0
+        ? `${t.predictionsPage.championHalfPointsNote}\n${changedChampionFields
+            .map((f) => `• ${f}`)
+            .join("\n")}`
+        : t.predictionsPage.updateConfirmBody
+    : t.predictionsPage.updateConfirmBody;
+
+  const pickerValue = pickerTarget ? getSlotValue(pickerTarget) : null;
+
+  const championPending = teamsQuery.isPending || championQuery.isPending;
+  const championError = teamsQuery.error ?? championQuery.error;
+  const sprintPending = sprintPredictionsQuery.isPending;
 
   return (
     <ScreenShell>
@@ -361,79 +817,249 @@ export default function RacePredictionScreen() {
           <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor="#CF2637" />
         }
       >
-        {/* ── Round selector ── */}
-        <View className="flex-row items-center gap-2">
-          <Pressable
-            onPress={() => setSelectedIndex(Math.max(0, raceIndex - 1))}
-            disabled={raceIndex === 0}
-            accessibilityRole="button"
-            accessibilityLabel={t.predictionsPage.previousRound}
-            className={`h-11 w-11 items-center justify-center rounded-xl border border-f1-white/10 active:bg-f1-white/10 ${
-              raceIndex === 0 ? "opacity-30" : ""
-            }`}
-          >
-            <Ionicons name="chevron-back" size={18} color="#F7F7F7" />
-          </Pressable>
+        {/* ── Tabs ── */}
+        <PredictionTabs
+          tab={tab}
+          hasSprint={currentRace.hasSprint}
+          sprintNeedsAttention={sprintNeedsAttention}
+          champNeedsAttention={champNeedsAttention}
+          onChange={setTab}
+        />
 
-          <Pressable
-            onPress={() => setRoundPickerOpen(true)}
-            accessibilityRole="button"
-            accessibilityLabel={`${t.predictionsPage.roundSelectorLabel}: R${currentRace.round} ${currentRace.raceName}`}
-            className="min-h-11 flex-1 flex-row items-center gap-2 rounded-xl border border-f1-white/10 bg-f1-white/5 px-3 py-2 active:bg-f1-white/10"
-          >
-            <Text className="text-base">{countryCodeToFlag(currentRace.countryCode)}</Text>
-            <View className="flex-1">
-              <Text className="text-xs font-bold tabular-nums text-f1-white/50">
-                R{String(currentRace.round).padStart(2, "0")}
-              </Text>
-              <Text className="text-sm font-semibold text-f1-white" numberOfLines={1}>
-                {currentRace.raceName}
-              </Text>
-              <Text className="text-xs text-f1-white/50">
-                {formatDate(currentRace.dateStart)} – {formatDate(currentRace.dateEnd)}
-              </Text>
-            </View>
-            <Ionicons name="chevron-down" size={16} color="#F7F7F766" />
-          </Pressable>
+        {/* ── Round selector (race + sprint tabs) / champion header ── */}
+        {!isChampionTab ? (
+          <View className="flex-row items-center gap-2">
+            <Pressable
+              onPress={() => selectRound(Math.max(0, raceIndex - 1))}
+              disabled={raceIndex === 0}
+              accessibilityRole="button"
+              accessibilityLabel={t.predictionsPage.previousRound}
+              className={`h-11 w-11 items-center justify-center rounded-xl border border-f1-white/10 active:bg-f1-white/10 ${
+                raceIndex === 0 ? "opacity-30" : ""
+              }`}
+            >
+              <Ionicons name="chevron-back" size={18} color="#F7F7F7" />
+            </Pressable>
 
-          <Pressable
-            onPress={() => setSelectedIndex(Math.min(races.length - 1, raceIndex + 1))}
-            disabled={raceIndex === races.length - 1}
-            accessibilityRole="button"
-            accessibilityLabel={t.predictionsPage.nextRound}
-            className={`h-11 w-11 items-center justify-center rounded-xl border border-f1-white/10 active:bg-f1-white/10 ${
-              raceIndex === races.length - 1 ? "opacity-30" : ""
-            }`}
-          >
-            <Ionicons name="chevron-forward" size={18} color="#F7F7F7" />
-          </Pressable>
-        </View>
+            <Pressable
+              onPress={() => setRoundPickerOpen(true)}
+              accessibilityRole="button"
+              accessibilityLabel={`${t.predictionsPage.roundSelectorLabel}: R${currentRace.round} ${currentRace.raceName}`}
+              className="min-h-11 flex-1 flex-row items-center gap-2 rounded-xl border border-f1-white/10 bg-f1-white/5 px-3 py-2 active:bg-f1-white/10"
+            >
+              <Text className="text-base">{countryCodeToFlag(currentRace.countryCode)}</Text>
+              <View className="flex-1">
+                <Text className="text-xs font-bold tabular-nums text-f1-white/50">
+                  R{String(currentRace.round).padStart(2, "0")}
+                </Text>
+                <Text className="text-sm font-semibold text-f1-white" numberOfLines={1}>
+                  {currentRace.raceName}
+                </Text>
+                <Text className="text-xs text-f1-white/50">
+                  {formatDate(currentRace.dateStart)} – {formatDate(currentRace.dateEnd)}
+                </Text>
+              </View>
+              <Ionicons name="chevron-down" size={16} color="#F7F7F766" />
+            </Pressable>
 
-        {/* ── Status row: race badge + countdown / closed banner ── */}
+            <Pressable
+              onPress={() => selectRound(Math.min(races.length - 1, raceIndex + 1))}
+              disabled={raceIndex === races.length - 1}
+              accessibilityRole="button"
+              accessibilityLabel={t.predictionsPage.nextRound}
+              className={`h-11 w-11 items-center justify-center rounded-xl border border-f1-white/10 active:bg-f1-white/10 ${
+                raceIndex === races.length - 1 ? "opacity-30" : ""
+              }`}
+            >
+              <Ionicons name="chevron-forward" size={18} color="#F7F7F7" />
+            </Pressable>
+          </View>
+        ) : (
+          <View className="flex-row items-center gap-2 rounded-xl border border-f1-white/10 bg-f1-white/5 px-3 py-3">
+            <Ionicons name="trophy" size={16} color="#FFB100" />
+            <Text className="flex-1 text-sm font-semibold text-f1-white">
+              {t.predictionsPage.championshipPredictions}
+            </Text>
+            {championPhase === "half" && (
+              <View className="rounded-full bg-f1-amber/15 px-2 py-0.5">
+                <Text className="text-[10px] font-semibold text-f1-amber">
+                  {t.predictionsPage.championHalfPointsPhase}
+                </Text>
+              </View>
+            )}
+            {championPhase === "closed" && (
+              <View className="rounded-full bg-f1-red/15 px-2 py-0.5">
+                <Text className="text-[10px] font-semibold text-f1-red">
+                  {t.predictionsPage.deadlinePassed}
+                </Text>
+              </View>
+            )}
+          </View>
+        )}
+
+        {/* ── Status row: badges + countdown / closed banner / results toggle ── */}
         <View className="gap-2">
           <View className="flex-row items-center gap-2">
-            <RaceStatusBadge status={raceStatus} />
+            {!isChampionTab && <RaceStatusBadge status={raceStatus} />}
             <PredictionStatusBadge status={status} />
+            {activeResultExists && (
+              <Pressable
+                onPress={() => setShowResults((v) => !v)}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  showResults ? t.predictionsPage.hideResults : t.predictionsPage.showResults
+                }
+                className="ml-auto min-h-8 flex-row items-center gap-1.5 px-1"
+              >
+                <Ionicons name={showResults ? "eye-off" : "eye"} size={13} color="#3C91E6" />
+                <Text className="text-xs font-medium text-f1-blue">
+                  {showResults ? t.predictionsPage.hideResults : t.predictionsPage.showResults}
+                </Text>
+              </Pressable>
+            )}
           </View>
-          {!deadlinePassed ? (
-            <CountdownBar
-              deadline={currentRace.dateEnd}
-              onExpire={() =>
-                setExpiredMeetingKeys((prev) => new Set(prev).add(currentRace.meetingKey))
-              }
-            />
-          ) : (
-            <View className="flex-row items-center gap-2 rounded-lg border border-f1-red/30 bg-f1-red/10 px-3 py-2">
-              <Ionicons name="time-outline" size={14} color="#CF2637" />
-              <Text className="text-xs font-semibold text-f1-red">
-                {t.predictionsPage.predictionsClosed}
-              </Text>
-            </View>
-          )}
+          {!isChampionTab &&
+            (!deadlinePassed ? (
+              <CountdownBar
+                deadline={activeDeadline}
+                onExpire={() => {
+                  const setter = tab === "sprint" ? setExpiredSprintKeys : setExpiredRaceKeys;
+                  setter((prev) => new Set(prev).add(currentRace.meetingKey));
+                }}
+              />
+            ) : (
+              <View className="flex-row items-center gap-2 rounded-lg border border-f1-red/30 bg-f1-red/10 px-3 py-2">
+                <Ionicons name="time-outline" size={14} color="#CF2637" />
+                <Text className="text-xs font-semibold text-f1-red">
+                  {t.predictionsPage.predictionsClosed}
+                </Text>
+              </View>
+            ))}
         </View>
 
+        {/* ── Results panel ── */}
+        {showResults && !isChampionTab && tab === "race" && currentResult && (
+          <RaceResultsPanel result={currentResult} />
+        )}
+        {showResults && tab === "sprint" && currentSprintResult && (
+          <SprintResultsPanel result={currentSprintResult} />
+        )}
+
         {/* ── Form ── */}
-        {currentPrediction ? (
+        {isChampionTab ? (
+          championError ? (
+            <View className="items-center gap-4 py-8">
+              <Text className="text-center text-sm text-f1-white/70">
+                {t.predictionsPage.loadError}
+              </Text>
+              <Pressable
+                onPress={() => {
+                  teamsQuery.refetch();
+                  championQuery.refetch();
+                }}
+                accessibilityRole="button"
+                accessibilityLabel={t.predictionsPage.retry}
+                className="min-h-11 items-center justify-center rounded-lg bg-f1-red px-6 active:bg-f1-red-hover"
+              >
+                <Text className="font-semibold text-white">{t.predictionsPage.retry}</Text>
+              </Pressable>
+            </View>
+          ) : championPending || !champPred || !teamBestPreds || !teamsWithDrivers ? (
+            <View className="items-center py-8">
+              <ActivityIndicator color="#CF2637" />
+            </View>
+          ) : (
+            <ChampionForm
+              prediction={champPred}
+              teamBestDriverPredictions={teamBestPreds}
+              teamsWithDrivers={teamsWithDrivers}
+              isEditable={isEditable}
+              championPhase={championPhase}
+              onPickDriver={(slot) => setPickerTarget({ kind: "champion", slot })}
+              onPickTeam={() => setTeamPickerOpen(true)}
+              onTeamBestDriverChange={(teamId, driverId, driverNumber) =>
+                setTeamBestPreds((prev) =>
+                  prev
+                    ? prev.map((p) =>
+                        p.teamId === teamId ? { ...p, driverId, driverNumber } : p
+                      )
+                    : prev
+                )
+              }
+            />
+          )
+        ) : tab === "sprint" ? (
+          sprintPending ? (
+            <View className="items-center py-8">
+              <ActivityIndicator color="#CF2637" />
+            </View>
+          ) : currentSprintPred ? (
+            <View className="gap-5">
+              {/* Sprint qualifying top 3 */}
+              <View className="gap-2">
+                <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-white/60">
+                  {t.predictionsPage.qualifyingTop3}
+                </Text>
+                {currentSprintPred.qualifyingTop3.map((driver, i) => (
+                  <DriverSlot
+                    key={`sq-${i}`}
+                    label={`Q${i + 1}`}
+                    value={driver}
+                    disabled={!isEditable}
+                    matchStatus={sprintMatchStatuses?.qualifyingTop3[i] ?? null}
+                    pointsAwarded={sprintFieldPoints?.qualifyingTop3[i] ?? null}
+                    onPress={() => setPickerTarget({ kind: "sprintQualifying", index: i })}
+                  />
+                ))}
+              </View>
+
+              {/* Sprint winner */}
+              <DriverSlot
+                label={t.predictionsPage.sprintWinnerP1}
+                value={currentSprintPred.sprintWinner}
+                disabled={!isEditable}
+                matchStatus={sprintMatchStatuses?.sprintWinner ?? null}
+                pointsAwarded={sprintFieldPoints?.sprintWinner ?? null}
+                onPress={() => setPickerTarget({ kind: "sprintWinner" })}
+              />
+
+              {/* Rest of top 8 */}
+              <View className="gap-2">
+                <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-white/60">
+                  {t.predictionsPage.restOfTop8}
+                </Text>
+                {currentSprintPred.restOfTop8.map((driver, i) => (
+                  <DriverSlot
+                    key={`sp-${i}`}
+                    label=""
+                    position={i + 2}
+                    value={driver}
+                    disabled={!isEditable}
+                    matchStatus={sprintMatchStatuses?.restOfTop8[i] ?? null}
+                    pointsAwarded={sprintFieldPoints?.restOfTop8[i] ?? null}
+                    onPress={() => setPickerTarget({ kind: "sprintRest", index: i })}
+                  />
+                ))}
+              </View>
+
+              {/* Fastest lap */}
+              <DriverSlot
+                label={t.predictionsPage.fastestLap}
+                value={currentSprintPred.fastestLap}
+                disabled={!isEditable}
+                matchStatus={sprintMatchStatuses?.fastestLap ?? null}
+                pointsAwarded={sprintFieldPoints?.fastestLap ?? null}
+                onPress={() => setPickerTarget({ kind: "sprintFastestLap" })}
+              />
+
+              <BonusBadges badges={sprintBonusBadges} />
+            </View>
+          ) : (
+            <Text className="py-8 text-center text-sm text-f1-white/50">
+              {t.predictionsPage.noSprintPredictions}
+            </Text>
+          )
+        ) : currentPrediction ? (
           <View className="gap-5">
             {/* Qualifying top 3 */}
             <View className="gap-2">
@@ -446,6 +1072,8 @@ export default function RacePredictionScreen() {
                   label={`Q${i + 1}`}
                   value={driver}
                   disabled={!isEditable}
+                  matchStatus={raceMatchStatuses?.qualifyingTop3[i] ?? null}
+                  pointsAwarded={raceFieldPoints?.qualifyingTop3[i] ?? null}
                   onPress={() => setPickerTarget({ kind: "qualifying", index: i })}
                 />
               ))}
@@ -456,6 +1084,8 @@ export default function RacePredictionScreen() {
               label={t.predictionsPage.raceWinner}
               value={currentPrediction.raceWinner}
               disabled={!isEditable}
+              matchStatus={raceMatchStatuses?.raceWinner ?? null}
+              pointsAwarded={raceFieldPoints?.raceWinner ?? null}
               onPress={() => setPickerTarget({ kind: "winner" })}
             />
 
@@ -471,6 +1101,8 @@ export default function RacePredictionScreen() {
                   position={i + 2}
                   value={driver}
                   disabled={!isEditable}
+                  matchStatus={raceMatchStatuses?.restOfTop10[i] ?? null}
+                  pointsAwarded={raceFieldPoints?.restOfTop10[i] ?? null}
                   onPress={() => setPickerTarget({ kind: "rest", index: i })}
                 />
               ))}
@@ -482,21 +1114,29 @@ export default function RacePredictionScreen() {
                 label={t.predictionsPage.fastestLap}
                 value={currentPrediction.fastestLap}
                 disabled={!isEditable}
+                matchStatus={raceMatchStatuses?.fastestLap ?? null}
+                pointsAwarded={raceFieldPoints?.fastestLap ?? null}
                 onPress={() => setPickerTarget({ kind: "fastestLap" })}
               />
               <DriverSlot
                 label={t.predictionsPage.fastestPitStop}
                 value={currentPrediction.fastestPitStop}
                 disabled={!isEditable}
+                matchStatus={raceMatchStatuses?.fastestPitStop ?? null}
+                pointsAwarded={raceFieldPoints?.fastestPitStop ?? null}
                 onPress={() => setPickerTarget({ kind: "fastestPitStop" })}
               />
               <DriverSlot
                 label={t.predictionsPage.driverOfTheDay}
                 value={currentPrediction.driverOfTheDay}
                 disabled={!isEditable}
+                matchStatus={raceMatchStatuses?.driverOfTheDay ?? null}
+                pointsAwarded={raceFieldPoints?.driverOfTheDay ?? null}
                 onPress={() => setPickerTarget({ kind: "driverOfTheDay" })}
               />
             </View>
+
+            <BonusBadges badges={raceBonusBadges} />
           </View>
         ) : (
           <Text className="py-8 text-center text-sm text-f1-white/50">
@@ -522,20 +1162,19 @@ export default function RacePredictionScreen() {
         {/* ── Points + actions bar ── */}
         <View className="flex-row items-center justify-between border-t border-f1-white/10 pt-4">
           <View className="flex-row items-center gap-2">
-            {currentPrediction?.pointsEarned !== null &&
-              currentPrediction?.pointsEarned !== undefined && (
-                <View className="flex-row items-center gap-1.5">
-                  <Ionicons name="trophy" size={16} color="#FFB100" />
-                  <Text className="text-base font-bold tabular-nums text-f1-amber">
-                    {currentPrediction.pointsEarned}
-                  </Text>
-                  <Text className="text-xs text-f1-white/50">{t.predictionsPage.ptsEarned}</Text>
-                </View>
-              )}
+            {pointsEarned !== null && (
+              <View className="flex-row items-center gap-1.5">
+                <Ionicons name="trophy" size={16} color="#FFB100" />
+                <Text className="text-base font-bold tabular-nums text-f1-amber">
+                  {pointsEarned}
+                </Text>
+                <Text className="text-xs text-f1-white/50">{t.predictionsPage.ptsEarned}</Text>
+              </View>
+            )}
           </View>
 
           <View className="flex-row items-center gap-2">
-            {isEditable && (
+            {isEditable && !isChampionTab && (
               <Pressable
                 onPress={() => setShowResetModal(true)}
                 disabled={isSaving}
@@ -551,7 +1190,7 @@ export default function RacePredictionScreen() {
                 </Text>
               </Pressable>
             )}
-            {deadlinePassed ? (
+            {actionsLocked ? (
               <View className="min-h-11 flex-row items-center gap-1.5 rounded-lg bg-f1-red/15 px-4">
                 <Ionicons name="time-outline" size={14} color="#CF2637" />
                 <Text className="text-sm font-semibold text-f1-red">
@@ -561,7 +1200,7 @@ export default function RacePredictionScreen() {
             ) : (
               <Pressable
                 onPress={() => {
-                  if (status === "submitted") {
+                  if (needsSubmitModal) {
                     setShowSubmitModal(true);
                   } else {
                     handleSubmit();
@@ -591,7 +1230,7 @@ export default function RacePredictionScreen() {
         races={races}
         selectedIndex={raceIndex}
         onSelect={(i) => {
-          setSelectedIndex(i);
+          selectRound(i);
           setRoundPickerOpen(false);
         }}
         onClose={() => setRoundPickerOpen(false)}
@@ -602,11 +1241,7 @@ export default function RacePredictionScreen() {
         label={pickerTarget ? getSlotLabel(pickerTarget) : ""}
         drivers={drivers}
         value={pickerValue}
-        disabledDrivers={
-          pickerTarget && currentPrediction
-            ? getDisabledForSlot(currentPrediction, pickerTarget)
-            : []
-        }
+        disabledDrivers={pickerTarget ? getDisabledForSlot(pickerTarget) : []}
         onSelect={(driver) => {
           if (pickerTarget) applySlot(pickerTarget, driver);
           setPickerTarget(null);
@@ -614,10 +1249,26 @@ export default function RacePredictionScreen() {
         onClose={() => setPickerTarget(null)}
       />
 
+      <TeamPickerModal
+        visible={teamPickerOpen}
+        label={t.predictionsPage.wcc}
+        teams={teamsWithDrivers ?? []}
+        value={champPred?.wccWinner ?? null}
+        onSelect={(teamName) => {
+          setChampPred((prev) => (prev ? { ...prev, wccWinner: teamName } : prev));
+          setTeamPickerOpen(false);
+        }}
+        onClose={() => setTeamPickerOpen(false)}
+      />
+
       <ConfirmModal
         visible={showResetModal}
         title={t.predictionsPage.resetPrediction}
-        subtitle={currentRace.raceName}
+        subtitle={
+          tab === "sprint"
+            ? `${t.predictionsPage.sprint} — ${currentRace.raceName}`
+            : currentRace.raceName
+        }
         body={`${t.predictionsPage.resetBody} ${t.predictionsPage.resetBodyPending}${t.predictionsPage.resetBodySuffix}`}
         confirmLabel={t.predictionsPage.resetConfirm}
         confirmingLabel={t.predictionsPage.resetting}
@@ -632,12 +1283,22 @@ export default function RacePredictionScreen() {
 
       <ConfirmModal
         visible={showSubmitModal}
-        title={t.predictionsPage.updateConfirmTitle}
-        subtitle={currentRace.raceName}
-        body={t.predictionsPage.updateConfirmBody}
+        title={
+          isChampionTab
+            ? t.predictionsPage.championUpdateTitle
+            : t.predictionsPage.updateConfirmTitle
+        }
+        subtitle={
+          isChampionTab
+            ? t.predictionsPage.championship
+            : tab === "sprint"
+              ? `${t.predictionsPage.sprint} — ${currentRace.raceName}`
+              : currentRace.raceName
+        }
+        body={submitModalBody}
         confirmLabel={t.predictionsPage.confirmUpdate}
         confirmingLabel={t.predictionsPage.updating}
-        tone="blue"
+        tone={isChampionTab ? "amber" : "blue"}
         isSaving={isSaving}
         onConfirm={() => {
           setShowSubmitModal(false);
@@ -647,6 +1308,21 @@ export default function RacePredictionScreen() {
       />
     </ScreenShell>
   );
+}
+
+/** Collapses each perfect/match bonus pair into at most one badge. */
+function buildBonusBadges(
+  pairs: { perfect: number; match: number; perfectLabel: string; matchLabel: string }[]
+): BonusBadge[] {
+  const badges: BonusBadge[] = [];
+  for (const pair of pairs) {
+    if (pair.perfect > 0) {
+      badges.push({ label: pair.perfectLabel, points: pair.perfect, tone: "green" });
+    } else if (pair.match > 0) {
+      badges.push({ label: pair.matchLabel, points: pair.match, tone: "amber" });
+    }
+  }
+  return badges;
 }
 
 /** Shared wrapper: dark background behind every screen state. The header

--- a/apps/mobile/src/components/predictions/BonusBadges.tsx
+++ b/apps/mobile/src/components/predictions/BonusBadges.tsx
@@ -1,0 +1,48 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+export interface BonusBadge {
+  label: string;
+  points: number;
+  tone: "green" | "amber";
+}
+
+/**
+ * Row of bonus pills (perfect/match podium, top 10/8, qualifying) shown under
+ * a scored prediction form — mirrors the web BonusBadges component.
+ */
+export function BonusBadges({ badges }: { badges: BonusBadge[] }) {
+  const { t } = useLanguage();
+  if (badges.length === 0) return null;
+  return (
+    <View className="gap-2 border-t border-f1-white/10 pt-3">
+      <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-white/60">
+        {t.predictionsPage.bonuses}
+      </Text>
+      <View className="flex-row flex-wrap gap-1.5">
+        {badges.map((b) => {
+          const tone =
+            b.tone === "green"
+              ? { box: "border-f1-green/30 bg-f1-green/10", text: "text-f1-green", icon: "#44AF69" }
+              : { box: "border-f1-amber/30 bg-f1-amber/10", text: "text-f1-amber", icon: "#FFB100" };
+          return (
+            <View
+              key={b.label}
+              accessible
+              accessibilityLabel={`${b.label} +${b.points}`}
+              className={`flex-row items-center gap-1 rounded-full border px-2 py-1 ${tone.box}`}
+            >
+              <Ionicons name="trophy" size={10} color={tone.icon} />
+              <Text className={`text-[10px] font-semibold ${tone.text}`}>{b.label}</Text>
+              <Text className={`text-[10px] font-bold tabular-nums ${tone.text}`}>
+                +{b.points}
+              </Text>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/predictions/ChampionForm.tsx
+++ b/apps/mobile/src/components/predictions/ChampionForm.tsx
@@ -1,0 +1,228 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Pressable, Text, View } from "react-native";
+import type { ChampionPredictionPhase } from "@f1/shared/lib/race-utils";
+import type { ChampionPrediction, TeamBestDriverPrediction, TeamWithDrivers } from "@f1/shared/types";
+
+import { DriverSlot } from "@/components/predictions/DriverSlot";
+import { useLanguage } from "@/providers/LanguageProvider";
+
+/** Champion driver slots handled by the parent's DriverPickerModal. */
+export type ChampionDriverSlot = "wdc" | "mostWins" | "mostPodiums" | "mostDnfs";
+
+interface ChampionFormProps {
+  prediction: ChampionPrediction;
+  teamBestDriverPredictions: TeamBestDriverPrediction[];
+  teamsWithDrivers: TeamWithDrivers[];
+  isEditable: boolean;
+  championPhase: ChampionPredictionPhase;
+  /** Opens the driver picker for one of the champion driver slots. */
+  onPickDriver: (slot: ChampionDriverSlot) => void;
+  /** Opens the team picker for the WCC slot. */
+  onPickTeam: () => void;
+  onTeamBestDriverChange: (teamId: number, driverId: number, driverNumber: number) => void;
+}
+
+function PointsPill({ points }: { points: number }) {
+  if (points <= 0) return null;
+  return (
+    <View className="rounded-full bg-f1-green/15 px-1.5 py-0.5">
+      <Text className="text-[9px] font-bold tabular-nums text-f1-green">+{points}</Text>
+    </View>
+  );
+}
+
+/**
+ * Season-champion prediction form: WDC/WCC winners, most wins/podiums/DNFs
+ * and the per-team best-driver picks — mirrors the web ChampionForm with
+ * touch-friendly slots and a bottom-sheet team picker owned by the parent.
+ */
+export function ChampionForm({
+  prediction,
+  teamBestDriverPredictions,
+  teamsWithDrivers,
+  isEditable,
+  championPhase,
+  onPickDriver,
+  onPickTeam,
+  onTeamBestDriverChange,
+}: ChampionFormProps) {
+  const { t } = useLanguage();
+  const scored = prediction.status === "scored";
+
+  return (
+    <View className="gap-5">
+      {/* Phase banner */}
+      {championPhase === "closed" ? (
+        <View className="flex-row items-center gap-2 rounded-lg border border-f1-red/30 bg-f1-red/10 px-3 py-2">
+          <Ionicons name="information-circle-outline" size={14} color="#CF2637" />
+          <Text className="flex-1 text-xs text-f1-red">
+            {t.predictionsPage.championClosedWarning}
+          </Text>
+        </View>
+      ) : championPhase === "half" ? (
+        <View className="flex-row items-center gap-2 rounded-lg border border-f1-amber/30 bg-f1-amber/10 px-3 py-2">
+          <Ionicons name="information-circle-outline" size={14} color="#FFB100" />
+          <Text className="flex-1 text-xs text-f1-amber">
+            {t.predictionsPage.halfPointsWarning}
+          </Text>
+        </View>
+      ) : (
+        <View className="flex-row items-center gap-2 rounded-lg border border-f1-blue/30 bg-f1-blue/10 px-3 py-2">
+          <Ionicons name="information-circle-outline" size={14} color="#3C91E6" />
+          <Text className="flex-1 text-xs text-f1-blue">
+            {t.predictionsPage.championshipInfoPhase1}
+          </Text>
+        </View>
+      )}
+
+      {/* WDC */}
+      <DriverSlot
+        label={t.predictionsPage.wdc}
+        value={prediction.wdcWinner}
+        disabled={!isEditable}
+        pointsAwarded={scored ? prediction.wdcPoints : null}
+        onPress={() => onPickDriver("wdc")}
+      />
+
+      {/* WCC */}
+      <View className="gap-1">
+        <View className="flex-row items-center gap-1">
+          <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-white/60">
+            {t.predictionsPage.wcc}
+          </Text>
+          {scored && (
+            <View className="ml-auto">
+              <PointsPill points={prediction.wccPoints} />
+            </View>
+          )}
+        </View>
+        <Pressable
+          onPress={onPickTeam}
+          disabled={!isEditable}
+          accessibilityRole="button"
+          accessibilityLabel={`${t.predictionsPage.wcc}: ${
+            prediction.wccWinner ?? t.predictionsPage.selectTeam
+          }`}
+          accessibilityState={{ disabled: !isEditable }}
+          className={`min-h-12 flex-row items-center gap-2 rounded-xl border px-3 py-2.5 ${
+            !isEditable
+              ? "border-f1-white/5 bg-f1-white/5 opacity-60"
+              : "border-f1-white/10 bg-f1-white/5 active:bg-f1-white/10"
+          }`}
+        >
+          {prediction.wccWinner ? (
+            <>
+              <View
+                className="h-6 w-1.5 rounded-full"
+                style={{
+                  backgroundColor: `#${
+                    teamsWithDrivers.find((team) => team.name === prediction.wccWinner)?.color ??
+                    "737373"
+                  }`,
+                }}
+              />
+              <Text className="flex-1 font-semibold text-f1-white" numberOfLines={1}>
+                {prediction.wccWinner}
+              </Text>
+            </>
+          ) : (
+            <Text className="flex-1 text-f1-white/40">{t.predictionsPage.selectTeam}</Text>
+          )}
+          <Ionicons name="chevron-down" size={14} color="#F7F7F766" />
+        </Pressable>
+      </View>
+
+      {/* Most Wins / Most Podiums / Most DNFs */}
+      <View className="gap-2 border-t border-f1-white/10 pt-4">
+        <DriverSlot
+          label={t.predictionsPage.mostWins}
+          value={prediction.mostWinsDriver}
+          disabled={!isEditable}
+          pointsAwarded={scored ? prediction.mostWinsPoints : null}
+          onPress={() => onPickDriver("mostWins")}
+        />
+        <DriverSlot
+          label={t.predictionsPage.mostPodiums}
+          value={prediction.mostPodiumsDriver}
+          disabled={!isEditable}
+          pointsAwarded={scored ? prediction.mostPodiumsPoints : null}
+          onPress={() => onPickDriver("mostPodiums")}
+        />
+        <DriverSlot
+          label={t.predictionsPage.mostDnfs}
+          value={prediction.mostDnfsDriver}
+          disabled={!isEditable}
+          pointsAwarded={scored ? prediction.mostDnfsPoints : null}
+          onPress={() => onPickDriver("mostDnfs")}
+        />
+      </View>
+
+      {/* Team Best Driver */}
+      <View className="gap-2 border-t border-f1-white/10 pt-4">
+        <View className="gap-0.5">
+          <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-white/60">
+            {t.predictionsPage.teamBestDriver}
+          </Text>
+          <Text className="text-[10px] text-f1-white/40">
+            {t.predictionsPage.teamBestDriverSub}
+          </Text>
+        </View>
+        {teamsWithDrivers.map((team) => {
+          const pred = teamBestDriverPredictions.find((p) => p.teamId === team.id);
+          const selectedDriverNumber = pred?.driverNumber ?? null;
+          return (
+            <View
+              key={team.id}
+              className="flex-row items-center gap-2 rounded-xl border border-f1-white/10 bg-f1-white/5 px-3 py-2"
+            >
+              <View
+                className="h-6 w-1.5 rounded-full"
+                style={{ backgroundColor: `#${team.color}` }}
+              />
+              <Text className="flex-1 text-xs font-medium text-f1-white" numberOfLines={1}>
+                {team.name}
+              </Text>
+              {pred?.isHalfPoints && (
+                <Text className="text-[10px] font-bold text-f1-amber">½</Text>
+              )}
+              {pred?.status === "scored" && <PointsPill points={pred.pointsEarned} />}
+              <View className="flex-row gap-1.5">
+                {team.drivers.map((d) => {
+                  const isSelected = selectedDriverNumber === d.driverNumber;
+                  return (
+                    <Pressable
+                      key={d.id}
+                      onPress={() => {
+                        if (!isEditable) return;
+                        onTeamBestDriverChange(team.id, d.id, d.driverNumber);
+                      }}
+                      disabled={!isEditable}
+                      accessibilityRole="button"
+                      accessibilityLabel={`${team.name}: ${d.firstName} ${d.lastName}`}
+                      accessibilityState={{ selected: isSelected, disabled: !isEditable }}
+                      className={`min-h-10 items-center justify-center rounded-lg px-3 ${
+                        isSelected
+                          ? "bg-f1-red"
+                          : !isEditable
+                            ? "bg-f1-white/5 opacity-50"
+                            : "bg-f1-white/10 active:bg-f1-white/20"
+                      }`}
+                    >
+                      <Text
+                        className={`text-[11px] font-semibold ${
+                          isSelected ? "text-white" : "text-f1-white/70"
+                        }`}
+                      >
+                        {d.nameAcronym}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/predictions/ConfirmModal.tsx
+++ b/apps/mobile/src/components/predictions/ConfirmModal.tsx
@@ -11,8 +11,8 @@ interface ConfirmModalProps {
   confirmLabel: string;
   /** Label swapped in while the request is in flight. */
   confirmingLabel: string;
-  /** Visual tone of the confirm button. */
-  tone: "red" | "blue";
+  /** Visual tone of the confirm button (amber = champion half-points warning). */
+  tone: "red" | "blue" | "amber";
   isSaving: boolean;
   onConfirm: () => void;
   onCancel: () => void;
@@ -35,7 +35,14 @@ export function ConfirmModal({
   onCancel,
 }: ConfirmModalProps) {
   const { t } = useLanguage();
-  const confirmBg = tone === "red" ? "bg-f1-red active:bg-f1-red-hover" : "bg-f1-blue active:bg-f1-blue/80";
+  const confirmBg =
+    tone === "red"
+      ? "bg-f1-red active:bg-f1-red-hover"
+      : tone === "amber"
+        ? "bg-f1-amber active:bg-f1-amber/80"
+        : "bg-f1-blue active:bg-f1-blue/80";
+  const confirmText = tone === "amber" ? "text-black" : "text-white";
+  const spinnerColor = tone === "amber" ? "#2A2B2A" : "#FFFFFF";
 
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
@@ -69,8 +76,8 @@ export function ConfirmModal({
                 isSaving ? "opacity-70" : ""
               }`}
             >
-              {isSaving ? <ActivityIndicator size="small" color="#FFFFFF" /> : null}
-              <Text className="text-sm font-semibold text-white">
+              {isSaving ? <ActivityIndicator size="small" color={spinnerColor} /> : null}
+              <Text className={`text-sm font-semibold ${confirmText}`}>
                 {isSaving ? confirmingLabel : confirmLabel}
               </Text>
             </Pressable>

--- a/apps/mobile/src/components/predictions/DriverSlot.tsx
+++ b/apps/mobile/src/components/predictions/DriverSlot.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Pressable, Text, View } from "react-native";
+import type { MatchStatus } from "@f1/shared/lib/prediction-status";
 import type { Driver } from "@f1/shared/types";
 
 import { useLanguage } from "@/providers/LanguageProvider";
@@ -11,6 +12,14 @@ interface DriverSlotProps {
   position?: number;
   value: Driver | null;
   disabled?: boolean;
+  /**
+   * Result-comparison status once the round has results: colors the slot
+   * green (exact) or amber (close ±1). Only rendered while disabled, matching
+   * the web DriverSelect.
+   */
+  matchStatus?: MatchStatus;
+  /** Points earned by this field once scored. When > 0, renders a `+N` badge. */
+  pointsAwarded?: number | null;
   onPress: () => void;
 }
 
@@ -18,11 +27,35 @@ interface DriverSlotProps {
  * A single tappable prediction slot. Tapping opens the DriverPickerModal;
  * this component only renders the current selection.
  */
-export function DriverSlot({ label, position, value, disabled = false, onPress }: DriverSlotProps) {
+export function DriverSlot({
+  label,
+  position,
+  value,
+  disabled = false,
+  matchStatus = null,
+  pointsAwarded = null,
+  onPress,
+}: DriverSlotProps) {
   const { t } = useLanguage();
   const placeholder = t.predictionsPage.selectDriverPlaceholder;
   const valueLabel = value ? `${value.firstName} ${value.lastName}` : placeholder;
   const fullLabel = position !== undefined ? `P${position} ${label}`.trim() : label;
+  const showPoints = pointsAwarded !== null && pointsAwarded > 0;
+
+  const matchLabel =
+    disabled && matchStatus === "exact"
+      ? t.predictionsPage.exactMatch
+      : disabled && matchStatus === "close"
+        ? t.predictionsPage.closeMatch
+        : null;
+
+  const boxClassName = disabled
+    ? matchStatus === "exact"
+      ? "border-f1-green/60 bg-f1-green/5"
+      : matchStatus === "close"
+        ? "border-f1-amber/60 bg-f1-amber/5"
+        : "border-f1-white/5 bg-f1-white/5 opacity-60"
+    : "border-f1-white/10 bg-f1-white/5 active:bg-f1-white/10";
 
   return (
     <View className="gap-1">
@@ -37,18 +70,23 @@ export function DriverSlot({ label, position, value, disabled = false, onPress }
             {label}
           </Text>
         )}
+        {showPoints && (
+          <View className="ml-auto rounded-full bg-f1-green/15 px-1.5 py-0.5">
+            <Text className="text-[9px] font-bold tabular-nums text-f1-green">
+              +{pointsAwarded}
+            </Text>
+          </View>
+        )}
       </View>
       <Pressable
         onPress={onPress}
         disabled={disabled}
         accessibilityRole="button"
-        accessibilityLabel={`${fullLabel}: ${valueLabel}`}
-        accessibilityState={{ disabled }}
-        className={`min-h-12 flex-row items-center gap-2 rounded-xl border px-3 py-2.5 ${
-          disabled
-            ? "border-f1-white/5 bg-f1-white/5 opacity-60"
-            : "border-f1-white/10 bg-f1-white/5 active:bg-f1-white/10"
+        accessibilityLabel={`${fullLabel}: ${valueLabel}${matchLabel ? `, ${matchLabel}` : ""}${
+          showPoints ? `, +${pointsAwarded}` : ""
         }`}
+        accessibilityState={{ disabled }}
+        className={`min-h-12 flex-row items-center gap-2 rounded-xl border px-3 py-2.5 ${boxClassName}`}
       >
         {value ? (
           <>

--- a/apps/mobile/src/components/predictions/PredictionTabs.tsx
+++ b/apps/mobile/src/components/predictions/PredictionTabs.tsx
@@ -1,0 +1,103 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Pressable, Text, View } from "react-native";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+export type PredictionTab = "race" | "sprint" | "champion";
+
+interface PredictionTabsProps {
+  tab: PredictionTab;
+  /** Whether the currently selected round has a sprint. */
+  hasSprint: boolean;
+  /** Pulses an amber dot on the Sprint tab while its deadline is open and it isn't scored. */
+  sprintNeedsAttention: boolean;
+  /** Shows an amber dot on the Champion tab while full-points submissions are open and it isn't scored. */
+  champNeedsAttention: boolean;
+  onChange: (tab: PredictionTab) => void;
+}
+
+/**
+ * Segmented Race / Sprint / Champion control shown under the screen header,
+ * mirroring the web's tab row (Sprint disabled with "N/A" on non-sprint
+ * rounds; Champion accented amber like the web champion pill).
+ */
+export function PredictionTabs({
+  tab,
+  hasSprint,
+  sprintNeedsAttention,
+  champNeedsAttention,
+  onChange,
+}: PredictionTabsProps) {
+  const { t } = useLanguage();
+
+  const items: {
+    key: PredictionTab;
+    label: string;
+    icon: keyof typeof Ionicons.glyphMap;
+    disabled: boolean;
+    dot: boolean;
+  }[] = [
+    { key: "race", label: t.predictionsPage.race, icon: "flag", disabled: false, dot: false },
+    {
+      key: "sprint",
+      label: t.predictionsPage.sprint,
+      icon: "flash",
+      disabled: !hasSprint,
+      dot: hasSprint && sprintNeedsAttention,
+    },
+    {
+      key: "champion",
+      label: t.predictionsPage.champion,
+      icon: "trophy",
+      disabled: false,
+      dot: champNeedsAttention,
+    },
+  ];
+
+  return (
+    <View className="flex-row rounded-xl border border-f1-white/10 bg-f1-white/5 p-1">
+      {items.map((item) => {
+        const active = tab === item.key;
+        const isChampion = item.key === "champion";
+        return (
+          <Pressable
+            key={item.key}
+            onPress={() => !item.disabled && onChange(item.key)}
+            disabled={item.disabled}
+            accessibilityRole="tab"
+            accessibilityLabel={item.label}
+            accessibilityState={{ selected: active, disabled: item.disabled }}
+            className={`min-h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-lg px-2 ${
+              active
+                ? isChampion
+                  ? "bg-f1-amber"
+                  : "bg-f1-red"
+                : item.disabled
+                  ? "opacity-30"
+                  : "active:bg-f1-white/10"
+            }`}
+          >
+            <Ionicons
+              name={item.icon}
+              size={13}
+              color={active ? (isChampion ? "#2A2B2A" : "#FFFFFF") : "#F7F7F799"}
+            />
+            <Text
+              className={`text-xs font-semibold ${
+                active ? (isChampion ? "text-black" : "text-white") : "text-f1-white/60"
+              }`}
+            >
+              {item.label}
+            </Text>
+            {item.disabled && (
+              <Text className="text-[9px] text-f1-white/40">{t.predictionsPage.na}</Text>
+            )}
+            {item.dot && !active && (
+              <View className="h-1.5 w-1.5 rounded-full bg-f1-amber" accessible={false} />
+            )}
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/predictions/ResultsPanel.tsx
+++ b/apps/mobile/src/components/predictions/ResultsPanel.tsx
@@ -1,0 +1,123 @@
+import { Text, View } from "react-native";
+import type { Driver, RaceResult, SprintResult } from "@f1/shared/types";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+/**
+ * Collapsible official-results panels shown above the prediction form once a
+ * round has results (mirrors the web ResultsDisplay / SprintResultsDisplay):
+ * headline fields (pole, winner, fastest lap, …), the qualifying top 3 and
+ * the full finishing order as compact chips.
+ */
+
+function ResultItem({ label, driver }: { label: string; driver: Driver }) {
+  return (
+    <View className="w-[47%] gap-0.5">
+      <Text className="text-[10px] text-f1-white/50">{label}</Text>
+      <View className="flex-row items-center gap-1.5">
+        <View
+          className="h-2 w-2 rounded-full"
+          style={{ backgroundColor: `#${driver.teamColor}` }}
+        />
+        <Text className="text-xs font-semibold text-f1-white">{driver.nameAcronym}</Text>
+        <Text className="flex-1 text-xs text-f1-white/50" numberOfLines={1}>
+          {driver.lastName}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function DriverChip({ prefix, driver }: { prefix: string; driver: Driver }) {
+  return (
+    <View className="flex-row items-center gap-1 rounded-md bg-f1-white/10 px-2 py-1">
+      <Text className="text-[10px] tabular-nums text-f1-white/50">{prefix}</Text>
+      <View
+        className="h-1.5 w-1.5 rounded-full"
+        style={{ backgroundColor: `#${driver.teamColor}` }}
+      />
+      <Text className="text-[10px] font-medium text-f1-white">{driver.nameAcronym}</Text>
+    </View>
+  );
+}
+
+function QualifyingChips({ drivers }: { drivers: Driver[] }) {
+  const { t } = useLanguage();
+  if (drivers.length === 0) return null;
+  return (
+    <View className="gap-1">
+      <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-white/50">
+        {t.predictionsPage.qualifyingTop3}
+      </Text>
+      <View className="flex-row flex-wrap gap-1.5">
+        {drivers.map((driver, i) => (
+          <DriverChip key={driver.driverNumber} prefix={`Q${i + 1}`} driver={driver} />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+export function RaceResultsPanel({ result }: { result: RaceResult }) {
+  const { t } = useLanguage();
+  return (
+    <View className="gap-3 rounded-xl border border-f1-green/20 bg-f1-green/5 p-3">
+      <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-green">
+        {t.predictionsPage.raceResults}
+      </Text>
+      <View className="flex-row flex-wrap gap-x-3 gap-y-2">
+        {result.qualifyingTop3[0] && (
+          <ResultItem label={t.predictionsPage.pole} driver={result.qualifyingTop3[0]} />
+        )}
+        <ResultItem label={t.predictionsPage.winner} driver={result.raceWinner} />
+        <ResultItem label={t.predictionsPage.fastestLap} driver={result.fastestLap} />
+        {result.fastestPitStop && (
+          <ResultItem label={t.predictionsPage.fastestPit} driver={result.fastestPitStop} />
+        )}
+        {result.driverOfTheDay && (
+          <ResultItem label={t.predictionsPage.driverOfTheDay} driver={result.driverOfTheDay} />
+        )}
+      </View>
+      <QualifyingChips drivers={result.qualifyingTop3} />
+      <View className="gap-1">
+        <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-white/50">
+          {t.predictionsPage.top10}
+        </Text>
+        <View className="flex-row flex-wrap gap-1.5">
+          {result.top10.map((driver, i) => (
+            <DriverChip key={driver.driverNumber} prefix={`${i + 1}.`} driver={driver} />
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function SprintResultsPanel({ result }: { result: SprintResult }) {
+  const { t } = useLanguage();
+  return (
+    <View className="gap-3 rounded-xl border border-f1-green/20 bg-f1-green/5 p-3">
+      <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-green">
+        {t.predictionsPage.sprintResults}
+      </Text>
+      <View className="flex-row flex-wrap gap-x-3 gap-y-2">
+        {result.qualifyingTop3[0] && (
+          <ResultItem label={t.predictionsPage.sprintPole} driver={result.qualifyingTop3[0]} />
+        )}
+        <ResultItem label={t.predictionsPage.sprintWinner} driver={result.sprintWinner} />
+        <ResultItem label={t.predictionsPage.fastestLap} driver={result.fastestLap} />
+      </View>
+      <QualifyingChips drivers={result.qualifyingTop3} />
+      <View className="gap-1">
+        <Text className="text-[10px] font-semibold uppercase tracking-wider text-f1-white/50">
+          {t.predictionsPage.top8}
+        </Text>
+        <View className="flex-row flex-wrap gap-1.5">
+          {result.top8.map((driver, i) => (
+            <DriverChip key={driver.driverNumber} prefix={`${i + 1}.`} driver={driver} />
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/predictions/TeamPickerModal.tsx
+++ b/apps/mobile/src/components/predictions/TeamPickerModal.tsx
@@ -1,0 +1,92 @@
+import { Ionicons } from "@expo/vector-icons";
+import { FlatList, Modal, Pressable, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import type { TeamWithDrivers } from "@f1/shared/types";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+interface TeamPickerModalProps {
+  visible: boolean;
+  /** Slot label shown in the sheet header (e.g. the WCC label). */
+  label: string;
+  teams: TeamWithDrivers[];
+  /** Currently selected team name, if any. */
+  value: string | null;
+  onSelect: (teamName: string) => void;
+  onClose: () => void;
+}
+
+/**
+ * Bottom-sheet team picker for the WCC champion prediction: one tappable row
+ * per team with its color bar — same styling as the DriverPickerModal.
+ */
+export function TeamPickerModal({
+  visible,
+  label,
+  teams,
+  value,
+  onSelect,
+  onClose,
+}: TeamPickerModalProps) {
+  const { t } = useLanguage();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View className="flex-1 justify-end bg-black/60">
+        <Pressable
+          className="flex-1"
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel={t.predictionsPage.dismiss}
+        />
+        <View
+          className="max-h-[75%] rounded-t-3xl border-t border-f1-white/10 bg-f1-black"
+          style={{ paddingBottom: insets.bottom }}
+        >
+          <View className="flex-row items-center justify-between border-b border-f1-white/10 px-5 py-4">
+            <Text className="flex-1 text-sm font-bold uppercase tracking-wider text-f1-white" numberOfLines={1}>
+              {label}
+            </Text>
+            <Pressable
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel={t.predictionsPage.dismiss}
+              className="h-8 w-8 items-center justify-center rounded-full bg-f1-white/10 active:bg-f1-white/20"
+            >
+              <Ionicons name="close" size={16} color="#F7F7F7" />
+            </Pressable>
+          </View>
+
+          <FlatList
+            data={teams}
+            keyExtractor={(team) => String(team.id)}
+            renderItem={({ item: team }) => {
+              const selected = value === team.name;
+              return (
+                <Pressable
+                  onPress={() => onSelect(team.name)}
+                  accessibilityRole="button"
+                  accessibilityLabel={team.name}
+                  accessibilityState={{ selected }}
+                  className={`min-h-14 flex-row items-center gap-3 px-5 py-2.5 ${
+                    selected ? "bg-f1-red/10" : "active:bg-f1-white/10"
+                  }`}
+                >
+                  <View
+                    className="h-9 w-1.5 rounded-full"
+                    style={{ backgroundColor: `#${team.color}` }}
+                  />
+                  <Text className="flex-1 text-sm font-semibold text-f1-white" numberOfLines={1}>
+                    {team.name}
+                  </Text>
+                  {selected ? <Ionicons name="checkmark" size={16} color="#CF2637" /> : null}
+                </Pressable>
+              );
+            }}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/web/__tests__/lib/champion-predictions.test.ts
+++ b/apps/web/__tests__/lib/champion-predictions.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for packages/shared/lib/champion-predictions.ts —
+ * fetchChampionPredictionData with mocked Supabase.
+ *
+ * Query order without a passed context (matters for the mock queues):
+ *   1. seasons (is_current)              — also re-queried inside fetchDrivers (sticky)
+ *   2. drivers (id, driver_number map)   — first "drivers" queue entry
+ *   3. races   (id, meeting_key map)
+ *   4. drivers (full rows, fetchDrivers) — second "drivers" queue entry
+ *   5. season_award_predictions (user rows)
+ *   6. teams (WCC team name — only when a wcc award has a team id)
+ */
+import { createMockSupabase } from "../helpers/mockSupabase";
+import { fetchChampionPredictionData } from "@f1/shared/lib/champion-predictions";
+import type { TeamWithDrivers } from "@f1/shared/types";
+
+const USER_ID = "user-123";
+const SEASON_ID = 7;
+
+/** DB driver id = 100 + driver number; 12 drivers, numbers 1..12. */
+const DRIVER_ID_ROWS = Array.from({ length: 12 }, (_, i) => ({
+  id: 101 + i,
+  driver_number: i + 1,
+}));
+
+const FULL_DRIVER_ROWS = Array.from({ length: 12 }, (_, i) => ({
+  driver_number: i + 1,
+  first_name: `First${i + 1}`,
+  last_name: `Last${i + 1}`,
+  name_acronym: `D${i + 1}`,
+  headshot_url: null,
+  team_id: 1,
+  teams: { name: "Team", color: "FF0000" },
+}));
+
+const TEAMS_WITH_DRIVERS: TeamWithDrivers[] = [
+  {
+    id: 1,
+    name: "Alpha",
+    color: "112233",
+    drivers: [
+      { id: 101, driverNumber: 1, firstName: "First1", lastName: "Last1", nameAcronym: "D1" },
+      { id: 102, driverNumber: 2, firstName: "First2", lastName: "Last2", nameAcronym: "D2" },
+    ],
+  },
+  {
+    id: 2,
+    name: "Beta",
+    color: "445566",
+    drivers: [
+      { id: 103, driverNumber: 3, firstName: "First3", lastName: "Last3", nameAcronym: "D3" },
+      { id: 104, driverNumber: 4, firstName: "First4", lastName: "Last4", nameAcronym: "D4" },
+    ],
+  },
+];
+
+function makeAwardRow(
+  slug: string,
+  overrides: Partial<{
+    id: string;
+    award_type_id: number;
+    driver_id: number | null;
+    team_id: number | null;
+    is_half_points: boolean;
+    status: string;
+    points_earned: number;
+  }> = {}
+) {
+  return {
+    id: `${slug}-row`,
+    award_type_id: 1,
+    driver_id: null,
+    team_id: null,
+    is_half_points: false,
+    status: "submitted",
+    points_earned: 0,
+    season_award_types: {
+      slug,
+      name: slug,
+      subject_type: slug === "wcc" ? "team" : "driver",
+      scope_team_id: null,
+      points_value: 10,
+      sort_order: 1,
+    },
+    ...overrides,
+  };
+}
+
+function setupBase() {
+  const { supabase, mockTable } = createMockSupabase();
+  mockTable("seasons", { data: { id: SEASON_ID }, error: null });
+  mockTable(
+    "drivers",
+    { data: DRIVER_ID_ROWS, error: null },
+    { data: FULL_DRIVER_ROWS, error: null }
+  );
+  mockTable("races", { data: [], error: null });
+  return { supabase, mockTable };
+}
+
+describe("fetchChampionPredictionData", () => {
+  it("returns pending placeholders when there is no current season", async () => {
+    const { supabase, mockTable } = createMockSupabase();
+    mockTable("seasons", { data: null, error: null });
+
+    const data = await fetchChampionPredictionData(supabase, USER_ID, TEAMS_WITH_DRIVERS);
+
+    expect(data.seasonAwardPredictions).toEqual([]);
+    expect(data.championPrediction.status).toBe("pending");
+    expect(data.championPrediction.wdcWinner).toBeNull();
+    expect(data.championPrediction.pointsEarned).toBe(0);
+    expect(data.teamBestDriverPredictions).toHaveLength(2);
+    expect(data.teamBestDriverPredictions[0]).toEqual({
+      teamId: 1,
+      teamName: "Alpha",
+      teamColor: "112233",
+      driverId: null,
+      driverNumber: null,
+      isHalfPoints: false,
+      status: "pending",
+      pointsEarned: 0,
+    });
+  });
+
+  it("returns a pending champion prediction when the user has no award rows", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("season_award_predictions", { data: null, error: null });
+
+    const data = await fetchChampionPredictionData(supabase, USER_ID, TEAMS_WITH_DRIVERS);
+
+    expect(data.championPrediction).toEqual({
+      userId: USER_ID,
+      status: "pending",
+      wdcWinner: null,
+      wccWinner: null,
+      mostDnfsDriver: null,
+      mostPodiumsDriver: null,
+      mostWinsDriver: null,
+      pointsEarned: 0,
+      wdcPoints: 0,
+      wccPoints: 0,
+      mostDnfsPoints: 0,
+      mostPodiumsPoints: 0,
+      mostWinsPoints: 0,
+      isHalfPoints: false,
+    });
+    expect(data.teamBestDriverPredictions.every((p) => p.status === "pending")).toBe(true);
+  });
+
+  it("assembles the champion prediction from award rows and resolves the WCC team name", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("season_award_predictions", {
+      data: [
+        makeAwardRow("wdc", { driver_id: 101 }),
+        makeAwardRow("wcc", { team_id: 2 }),
+        makeAwardRow("most_dnfs", { driver_id: 103 }),
+        makeAwardRow("most_podiums", { driver_id: 104 }),
+        makeAwardRow("most_wins", { driver_id: 105 }),
+      ],
+      error: null,
+    });
+    mockTable("teams", { data: { name: "Beta" }, error: null });
+
+    const data = await fetchChampionPredictionData(supabase, USER_ID, TEAMS_WITH_DRIVERS);
+    const champ = data.championPrediction;
+
+    expect(champ.status).toBe("submitted");
+    expect(champ.wdcWinner?.driverNumber).toBe(1);
+    expect(champ.wccWinner).toBe("Beta");
+    expect(champ.mostDnfsDriver?.driverNumber).toBe(3);
+    expect(champ.mostPodiumsDriver?.driverNumber).toBe(4);
+    expect(champ.mostWinsDriver?.driverNumber).toBe(5);
+    expect(champ.isHalfPoints).toBe(false);
+    expect(data.seasonAwardPredictions).toHaveLength(5);
+  });
+
+  it("marks the champion prediction scored and sums per-field points once any award is scored", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("season_award_predictions", {
+      data: [
+        makeAwardRow("wdc", { driver_id: 101, status: "scored", points_earned: 20 }),
+        makeAwardRow("most_wins", { driver_id: 102, status: "scored", points_earned: 10 }),
+      ],
+      error: null,
+    });
+
+    const data = await fetchChampionPredictionData(supabase, USER_ID, TEAMS_WITH_DRIVERS);
+    const champ = data.championPrediction;
+
+    expect(champ.status).toBe("scored");
+    expect(champ.pointsEarned).toBe(30);
+    expect(champ.wdcPoints).toBe(20);
+    expect(champ.mostWinsPoints).toBe(10);
+    expect(champ.wccPoints).toBe(0);
+  });
+
+  it("flags half points when any champion award is half points", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("season_award_predictions", {
+      data: [makeAwardRow("wdc", { driver_id: 101, is_half_points: true })],
+      error: null,
+    });
+
+    const data = await fetchChampionPredictionData(supabase, USER_ID, TEAMS_WITH_DRIVERS);
+    expect(data.championPrediction.isHalfPoints).toBe(true);
+  });
+
+  it("maps team best driver awards onto the passed teams, resolving driver numbers", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("season_award_predictions", {
+      data: [
+        makeAwardRow("best_driver_1", {
+          driver_id: 102,
+          status: "scored",
+          points_earned: 5,
+          is_half_points: true,
+        }),
+      ],
+      error: null,
+    });
+
+    const data = await fetchChampionPredictionData(supabase, USER_ID, TEAMS_WITH_DRIVERS);
+    const [alpha, beta] = data.teamBestDriverPredictions;
+
+    expect(alpha.driverId).toBe(102);
+    expect(alpha.driverNumber).toBe(2);
+    expect(alpha.status).toBe("scored");
+    expect(alpha.pointsEarned).toBe(5);
+    expect(alpha.isHalfPoints).toBe(true);
+    expect(beta.driverId).toBeNull();
+    expect(beta.driverNumber).toBeNull();
+    expect(beta.status).toBe("pending");
+  });
+
+  it("leaves the WCC winner null when the team lookup finds nothing", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("season_award_predictions", {
+      data: [makeAwardRow("wcc", { team_id: 99 })],
+      error: null,
+    });
+    mockTable("teams", { data: null, error: null });
+
+    const data = await fetchChampionPredictionData(supabase, USER_ID, TEAMS_WITH_DRIVERS);
+    expect(data.championPrediction.wccWinner).toBeNull();
+    // The wcc award still counts toward the overall status.
+    expect(data.championPrediction.status).toBe("submitted");
+  });
+});

--- a/apps/web/__tests__/lib/prediction-status.test.ts
+++ b/apps/web/__tests__/lib/prediction-status.test.ts
@@ -1,8 +1,18 @@
 /**
  * Tests for packages/shared/lib/prediction-status.ts — pure function, no mocks.
  */
-import { proximityStatus } from "@f1/shared/lib/prediction-status";
-import type { Driver } from "@f1/shared/types";
+import {
+  computeRaceMatchStatuses,
+  computeSprintMatchStatuses,
+  proximityStatus,
+} from "@f1/shared/lib/prediction-status";
+import type {
+  Driver,
+  FullRacePrediction,
+  RaceResult,
+  SprintPrediction,
+  SprintResult,
+} from "@f1/shared/types";
 
 function makeDriver(driverNumber: number, acronym = `D${driverNumber}`): Driver {
   return {
@@ -96,5 +106,163 @@ describe("proximityStatus", () => {
     const sparse = [makeDriver(1), undefined as unknown as Driver, makeDriver(3)];
     expect(proximityStatus(makeDriver(3), sparse, null, 3, 2)).toBe("exact");
     expect(proximityStatus(makeDriver(2), sparse, null, 3, 1)).toBe("miss");
+  });
+});
+
+/* ── computeRaceMatchStatuses / computeSprintMatchStatuses ─────────────── */
+
+const RACE_RESULT: RaceResult = {
+  raceId: 9001,
+  qualifyingTop3: [makeDriver(1), makeDriver(2), makeDriver(3)],
+  qualifyingP4: makeDriver(4),
+  raceWinner: top10[0],
+  top10,
+  p11,
+  fastestLap: makeDriver(5),
+  fastestPitStop: makeDriver(6),
+  driverOfTheDay: makeDriver(7),
+};
+
+function makeRacePrediction(overrides: Partial<FullRacePrediction> = {}): FullRacePrediction {
+  return {
+    raceId: 9001,
+    userId: "user-123",
+    status: "scored",
+    qualifyingTop3: [null, null, null],
+    raceWinner: null,
+    restOfTop10: Array(9).fill(null),
+    fastestLap: null,
+    fastestPitStop: null,
+    driverOfTheDay: null,
+    pointsEarned: null,
+    ...overrides,
+  };
+}
+
+describe("computeRaceMatchStatuses", () => {
+  it("returns all-null statuses for an empty prediction", () => {
+    const statuses = computeRaceMatchStatuses(makeRacePrediction(), RACE_RESULT);
+    expect(statuses.qualifyingTop3).toEqual([null, null, null]);
+    expect(statuses.raceWinner).toBeNull();
+    expect(statuses.restOfTop10).toEqual(Array(9).fill(null));
+    expect(statuses.fastestLap).toBeNull();
+    expect(statuses.fastestPitStop).toBeNull();
+    expect(statuses.driverOfTheDay).toBeNull();
+  });
+
+  it("applies ±1 proximity to the top 10 with the P11 boundary", () => {
+    const prediction = makeRacePrediction({
+      raceWinner: makeDriver(1), // exact P1
+      restOfTop10: [
+        makeDriver(3), // P2 slot, finished P3 → close
+        makeDriver(9), // P3 slot, finished P9 → miss
+        ...Array(5).fill(null),
+        makeDriver(99), // P9 slot, not in results → miss
+        p11, // P10 slot, boundary P11 → close
+      ],
+    });
+    const statuses = computeRaceMatchStatuses(prediction, RACE_RESULT);
+    expect(statuses.raceWinner).toBe("exact");
+    expect(statuses.restOfTop10[0]).toBe("close");
+    expect(statuses.restOfTop10[1]).toBe("miss");
+    expect(statuses.restOfTop10[7]).toBe("miss");
+    expect(statuses.restOfTop10[8]).toBe("close");
+  });
+
+  it("applies ±1 proximity to qualifying with the Q4 boundary", () => {
+    const prediction = makeRacePrediction({
+      qualifyingTop3: [makeDriver(1), makeDriver(3), makeDriver(4)],
+    });
+    const statuses = computeRaceMatchStatuses(prediction, RACE_RESULT);
+    expect(statuses.qualifyingTop3).toEqual(["exact", "close", "close"]);
+  });
+
+  it("uses exact-only matching for the special fields", () => {
+    const prediction = makeRacePrediction({
+      fastestLap: makeDriver(5), // matches
+      fastestPitStop: makeDriver(5), // does not match #6
+      driverOfTheDay: makeDriver(7), // matches
+    });
+    const statuses = computeRaceMatchStatuses(prediction, RACE_RESULT);
+    expect(statuses.fastestLap).toBe("exact");
+    expect(statuses.fastestPitStop).toBeNull();
+    expect(statuses.driverOfTheDay).toBe("exact");
+  });
+
+  it("returns null for optional special fields missing from the result", () => {
+    const result: RaceResult = {
+      ...RACE_RESULT,
+      fastestPitStop: undefined,
+      driverOfTheDay: undefined,
+    };
+    const prediction = makeRacePrediction({
+      fastestPitStop: makeDriver(6),
+      driverOfTheDay: makeDriver(7),
+    });
+    const statuses = computeRaceMatchStatuses(prediction, result);
+    expect(statuses.fastestPitStop).toBeNull();
+    expect(statuses.driverOfTheDay).toBeNull();
+  });
+});
+
+const top8 = Array.from({ length: 8 }, (_, i) => makeDriver(i + 1));
+const p9 = makeDriver(9);
+
+const SPRINT_RESULT: SprintResult = {
+  raceId: 9002,
+  qualifyingTop3: [makeDriver(1), makeDriver(2), makeDriver(3)],
+  qualifyingP4: makeDriver(4),
+  sprintWinner: top8[0],
+  top8,
+  p9,
+  fastestLap: makeDriver(2),
+};
+
+function makeSprintPrediction(overrides: Partial<SprintPrediction> = {}): SprintPrediction {
+  return {
+    raceId: 9002,
+    userId: "user-123",
+    status: "scored",
+    qualifyingTop3: [null, null, null],
+    sprintWinner: null,
+    restOfTop8: Array(7).fill(null),
+    fastestLap: null,
+    pointsEarned: null,
+    ...overrides,
+  };
+}
+
+describe("computeSprintMatchStatuses", () => {
+  it("returns all-null statuses for an empty prediction", () => {
+    const statuses = computeSprintMatchStatuses(makeSprintPrediction(), SPRINT_RESULT);
+    expect(statuses.qualifyingTop3).toEqual([null, null, null]);
+    expect(statuses.sprintWinner).toBeNull();
+    expect(statuses.restOfTop8).toEqual(Array(7).fill(null));
+    expect(statuses.fastestLap).toBeNull();
+  });
+
+  it("applies ±1 proximity to the top 8 with the P9 boundary", () => {
+    const prediction = makeSprintPrediction({
+      sprintWinner: makeDriver(2), // finished P2 → close
+      restOfTop8: [
+        makeDriver(2), // P2 slot → exact
+        ...Array(5).fill(null),
+        p9, // P8 slot, boundary P9 → close
+      ],
+    });
+    const statuses = computeSprintMatchStatuses(prediction, SPRINT_RESULT);
+    expect(statuses.sprintWinner).toBe("close");
+    expect(statuses.restOfTop8[0]).toBe("exact");
+    expect(statuses.restOfTop8[6]).toBe("close");
+  });
+
+  it("applies ±1 proximity to sprint qualifying and exact-only to the fastest lap", () => {
+    const prediction = makeSprintPrediction({
+      qualifyingTop3: [makeDriver(2), makeDriver(2), makeDriver(99)],
+      fastestLap: makeDriver(2),
+    });
+    const statuses = computeSprintMatchStatuses(prediction, SPRINT_RESULT);
+    expect(statuses.qualifyingTop3).toEqual(["close", "exact", "miss"]);
+    expect(statuses.fastestLap).toBe("exact");
   });
 });

--- a/apps/web/__tests__/lib/results.test.ts
+++ b/apps/web/__tests__/lib/results.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for packages/shared/lib/results.ts — fetchRaceResults,
+ * fetchSprintResults and buildResultQualifyingTop3, with mocked Supabase.
+ *
+ * Query order without a passed context (matters for the mock queues):
+ *   1. seasons (is_current)              — also re-queried inside fetchDrivers (sticky)
+ *   2. drivers (id, driver_number map)   — first "drivers" queue entry
+ *   3. races   (id, meeting_key map)
+ *   4. drivers (full rows, fetchDrivers) — second "drivers" queue entry
+ *   5. race_results / sprint_results
+ */
+import { createMockSupabase } from "../helpers/mockSupabase";
+import {
+  buildResultQualifyingTop3,
+  fetchRaceResults,
+  fetchSprintResults,
+} from "@f1/shared/lib/results";
+import type { Driver } from "@f1/shared/types";
+
+const SEASON_ID = 7;
+
+/** DB driver id = 100 + driver number; 12 drivers, numbers 1..12. */
+const DRIVER_ID_ROWS = Array.from({ length: 12 }, (_, i) => ({
+  id: 101 + i,
+  driver_number: i + 1,
+}));
+
+const FULL_DRIVER_ROWS = Array.from({ length: 12 }, (_, i) => ({
+  driver_number: i + 1,
+  first_name: `First${i + 1}`,
+  last_name: `Last${i + 1}`,
+  name_acronym: `D${i + 1}`,
+  headshot_url: null,
+  team_id: 1,
+  teams: { name: "Team", color: "FF0000" },
+}));
+
+const DB_RACES = [
+  { id: 501, meeting_key: 9001 },
+  { id: 502, meeting_key: 9002 },
+];
+
+function setupBase() {
+  const { supabase, mockTable } = createMockSupabase();
+  mockTable("seasons", { data: { id: SEASON_ID }, error: null });
+  mockTable(
+    "drivers",
+    { data: DRIVER_ID_ROWS, error: null },
+    { data: FULL_DRIVER_ROWS, error: null }
+  );
+  mockTable("races", { data: DB_RACES, error: null });
+  return { supabase, mockTable };
+}
+
+describe("buildResultQualifyingTop3", () => {
+  const driver = (n: number): Driver => ({
+    driverNumber: n,
+    firstName: `First${n}`,
+    lastName: `Last${n}`,
+    nameAcronym: `D${n}`,
+    teamName: "Team",
+    teamColor: "FF0000",
+  });
+  const findDriver = (id: number | null) =>
+    id !== null && id >= 101 && id <= 112 ? driver(id - 100) : null;
+
+  it("maps the stored array and drops unresolved ids", () => {
+    const result = buildResultQualifyingTop3([103, 9999, 101], null, findDriver);
+    expect(result.map((d) => d.driverNumber)).toEqual([3, 1]);
+  });
+
+  it("falls back to the legacy pole id when the array is empty", () => {
+    const result = buildResultQualifyingTop3([], 105, findDriver);
+    expect(result.map((d) => d.driverNumber)).toEqual([5]);
+  });
+
+  it("returns [] when both sources are empty", () => {
+    expect(buildResultQualifyingTop3(null, null, findDriver)).toEqual([]);
+  });
+});
+
+describe("fetchRaceResults", () => {
+  const COMPLETE_ROW = {
+    race_id: 501,
+    pole_position_driver_id: null,
+    qualifying_top_3: [102, 101, 103],
+    qualifying_p4_driver_id: 104,
+    top_10: [101, 102, 103, 104, 105, 106, 107, 108, 109, 110],
+    p11_driver_id: 111,
+    fastest_lap_driver_id: 105,
+    fastest_pit_stop_driver_id: 106,
+    driver_of_the_day_driver_id: 107,
+  };
+
+  it("returns an empty record when there is no current season", async () => {
+    const { supabase, mockTable } = createMockSupabase();
+    mockTable("seasons", { data: null, error: null });
+
+    expect(await fetchRaceResults(supabase)).toEqual({});
+  });
+
+  it("maps a complete result row keyed by meeting key", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_results", { data: [COMPLETE_ROW], error: null });
+
+    const results = await fetchRaceResults(supabase);
+    const result = results[9001];
+
+    expect(result).toBeDefined();
+    expect(result.raceId).toBe(9001);
+    expect(result.raceWinner.driverNumber).toBe(1);
+    expect(result.top10.map((d) => d.driverNumber)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result.qualifyingTop3.map((d) => d.driverNumber)).toEqual([2, 1, 3]);
+    expect(result.qualifyingP4?.driverNumber).toBe(4);
+    expect(result.p11?.driverNumber).toBe(11);
+    expect(result.fastestLap.driverNumber).toBe(5);
+    expect(result.fastestPitStop?.driverNumber).toBe(6);
+    expect(result.driverOfTheDay?.driverNumber).toBe(7);
+  });
+
+  it("omits optional fields that are not stored", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_results", {
+      data: [
+        {
+          ...COMPLETE_ROW,
+          qualifying_p4_driver_id: null,
+          p11_driver_id: null,
+          fastest_pit_stop_driver_id: null,
+          driver_of_the_day_driver_id: null,
+        },
+      ],
+      error: null,
+    });
+
+    const result = (await fetchRaceResults(supabase))[9001];
+    expect(result.qualifyingP4).toBeUndefined();
+    expect(result.p11).toBeUndefined();
+    expect(result.fastestPitStop).toBeUndefined();
+    expect(result.driverOfTheDay).toBeUndefined();
+  });
+
+  it("skips incomplete rows (no fastest lap) and rows for unknown race ids", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_results", {
+      data: [
+        { ...COMPLETE_ROW, fastest_lap_driver_id: null },
+        { ...COMPLETE_ROW, race_id: 999 },
+      ],
+      error: null,
+    });
+
+    expect(await fetchRaceResults(supabase)).toEqual({});
+  });
+
+  it("falls back to the legacy pole column for the qualifying result", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("race_results", {
+      data: [{ ...COMPLETE_ROW, qualifying_top_3: null, pole_position_driver_id: 108 }],
+      error: null,
+    });
+
+    const result = (await fetchRaceResults(supabase))[9001];
+    expect(result.qualifyingTop3.map((d) => d.driverNumber)).toEqual([8]);
+  });
+});
+
+describe("fetchSprintResults", () => {
+  const COMPLETE_ROW = {
+    race_id: 502,
+    sprint_pole_driver_id: null,
+    qualifying_top_3: [101, 102, 103],
+    qualifying_p4_driver_id: 104,
+    top_8: [102, 101, 103, 104, 105, 106, 107, 108],
+    p9_driver_id: 109,
+    fastest_lap_driver_id: 110,
+  };
+
+  it("returns an empty record when there is no current season", async () => {
+    const { supabase, mockTable } = createMockSupabase();
+    mockTable("seasons", { data: null, error: null });
+
+    expect(await fetchSprintResults(supabase)).toEqual({});
+  });
+
+  it("maps a complete sprint result row keyed by meeting key", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("sprint_results", { data: [COMPLETE_ROW], error: null });
+
+    const result = (await fetchSprintResults(supabase))[9002];
+
+    expect(result).toBeDefined();
+    expect(result.sprintWinner.driverNumber).toBe(2);
+    expect(result.top8.map((d) => d.driverNumber)).toEqual([2, 1, 3, 4, 5, 6, 7, 8]);
+    expect(result.qualifyingTop3.map((d) => d.driverNumber)).toEqual([1, 2, 3]);
+    expect(result.qualifyingP4?.driverNumber).toBe(4);
+    expect(result.p9?.driverNumber).toBe(9);
+    expect(result.fastestLap.driverNumber).toBe(10);
+  });
+
+  it("skips rows without a Q1 driver", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("sprint_results", {
+      data: [{ ...COMPLETE_ROW, qualifying_top_3: null, sprint_pole_driver_id: null }],
+      error: null,
+    });
+
+    expect(await fetchSprintResults(supabase)).toEqual({});
+  });
+});

--- a/apps/web/__tests__/lib/sprint-predictions.test.ts
+++ b/apps/web/__tests__/lib/sprint-predictions.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for fetchUserSprintPredictions and createPredictionContext
+ * (packages/shared/lib/predictions.ts) — service layer with mocked Supabase.
+ *
+ * Query order inside fetchUserSprintPredictions (matters for the mock queues):
+ *   1. seasons (is_current)              — also re-queried inside fetchDrivers (sticky)
+ *   2. drivers (id, driver_number map)   — first "drivers" queue entry
+ *   3. races   (id, meeting_key map)
+ *   4. drivers (full rows, fetchDrivers) — second "drivers" queue entry
+ *   5. sprint_predictions (user rows)
+ */
+import { createMockSupabase } from "../helpers/mockSupabase";
+import {
+  createPredictionContext,
+  fetchUserSprintPredictions,
+} from "@f1/shared/lib/predictions";
+import type { Race } from "@f1/shared/types";
+
+const USER_ID = "user-123";
+const SEASON_ID = 7;
+
+function makeRace(meetingKey: number, round: number, hasSprint = true): Race {
+  return {
+    meetingKey,
+    raceName: `Race ${round}`,
+    officialName: `Official Race ${round}`,
+    circuitShortName: `Circuit ${round}`,
+    countryName: "Country",
+    countryCode: "CC",
+    location: "Location",
+    dateStart: "2026-03-01T00:00:00Z",
+    dateEnd: "2026-03-03T00:00:00Z",
+    sprintDateEnd: hasSprint ? "2026-03-02T00:00:00Z" : null,
+    round,
+    hasSprint,
+  };
+}
+
+/** DB driver id = 100 + driver number; 12 drivers, numbers 1..12. */
+const DRIVER_ID_ROWS = Array.from({ length: 12 }, (_, i) => ({
+  id: 101 + i,
+  driver_number: i + 1,
+}));
+
+const FULL_DRIVER_ROWS = Array.from({ length: 12 }, (_, i) => ({
+  driver_number: i + 1,
+  first_name: `First${i + 1}`,
+  last_name: `Last${i + 1}`,
+  name_acronym: `D${i + 1}`,
+  headshot_url: null,
+  team_id: 1,
+  teams: { name: "Team", color: "FF0000" },
+}));
+
+const DB_RACES = [
+  { id: 501, meeting_key: 9001 },
+  { id: 502, meeting_key: 9002 },
+];
+
+/** Standard fixture: current season, 12 drivers, 2 races. */
+function setupBase() {
+  const { supabase, mockTable } = createMockSupabase();
+  mockTable("seasons", { data: { id: SEASON_ID }, error: null });
+  mockTable(
+    "drivers",
+    { data: DRIVER_ID_ROWS, error: null },
+    { data: FULL_DRIVER_ROWS, error: null }
+  );
+  mockTable("races", { data: DB_RACES, error: null });
+  return { supabase, mockTable };
+}
+
+describe("createPredictionContext", () => {
+  it("returns null when there is no current season", async () => {
+    const { supabase, mockTable } = createMockSupabase();
+    mockTable("seasons", { data: null, error: null });
+
+    expect(await createPredictionContext(supabase)).toBeNull();
+  });
+
+  it("builds the race mapping, driver list and driver resolver", async () => {
+    const { supabase } = setupBase();
+    const ctx = await createPredictionContext(supabase);
+
+    expect(ctx).not.toBeNull();
+    expect(ctx!.seasonId).toBe(SEASON_ID);
+    expect(ctx!.raceIdToMeetingKey.get(501)).toBe(9001);
+    expect(ctx!.raceIdToMeetingKey.get(502)).toBe(9002);
+    expect(ctx!.allDrivers).toHaveLength(12);
+    expect(ctx!.findDriver(103)?.driverNumber).toBe(3);
+    expect(ctx!.findDriver(9999)).toBeNull();
+    expect(ctx!.findDriver(null)).toBeNull();
+  });
+});
+
+describe("fetchUserSprintPredictions", () => {
+  it("returns an empty array when there is no current season", async () => {
+    const { supabase, mockTable } = createMockSupabase();
+    mockTable("seasons", { data: null, error: null });
+
+    const result = await fetchUserSprintPredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(result).toEqual([]);
+  });
+
+  it("only returns entries for races that have a sprint", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("sprint_predictions", { data: null, error: null });
+
+    const races = [makeRace(9001, 1, true), makeRace(9002, 2, false)];
+    const result = await fetchUserSprintPredictions(supabase, USER_ID, races);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].raceId).toBe(9001);
+  });
+
+  it("returns a pending placeholder with all-null slots when the user has no rows", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("sprint_predictions", { data: null, error: null });
+
+    const [prediction] = await fetchUserSprintPredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(prediction).toEqual({
+      raceId: 9001,
+      userId: USER_ID,
+      status: "pending",
+      qualifyingTop3: [null, null, null],
+      sprintWinner: null,
+      restOfTop8: Array(7).fill(null),
+      fastestLap: null,
+      pointsEarned: null,
+    });
+  });
+
+  it("maps a full stored prediction: winner from top_8[0], rest from indexes 1..7, quali, fastest lap, points", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("sprint_predictions", {
+      data: [
+        {
+          race_id: 501,
+          status: "scored",
+          sprint_pole_driver_id: 103, // ignored when qualifying_top_3 is set
+          qualifying_top_3: [103, 101, 102],
+          top_8: [101, 102, 103, 104, 105, 106, 107, 108],
+          fastest_lap_driver_id: 104,
+          points_earned: 21,
+        },
+      ],
+      error: null,
+    });
+
+    const [prediction] = await fetchUserSprintPredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+
+    expect(prediction.status).toBe("scored");
+    expect(prediction.pointsEarned).toBe(21);
+    expect(prediction.sprintWinner?.driverNumber).toBe(1);
+    expect(prediction.restOfTop8).toHaveLength(7);
+    expect(prediction.restOfTop8.map((d) => d?.driverNumber)).toEqual([2, 3, 4, 5, 6, 7, 8]);
+    expect(prediction.qualifyingTop3.map((d) => d?.driverNumber ?? null)).toEqual([3, 1, 2]);
+    expect(prediction.fastestLap?.driverNumber).toBe(4);
+  });
+
+  it("falls back to the legacy sprint_pole_driver_id as Q1 when qualifying_top_3 is empty", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("sprint_predictions", {
+      data: [
+        {
+          race_id: 501,
+          status: "submitted",
+          sprint_pole_driver_id: 107,
+          qualifying_top_3: [],
+          top_8: [101],
+          fastest_lap_driver_id: null,
+          points_earned: null,
+        },
+      ],
+      error: null,
+    });
+
+    const [prediction] = await fetchUserSprintPredictions(supabase, USER_ID, [makeRace(9001, 1)]);
+    expect(prediction.qualifyingTop3.map((d) => d?.driverNumber ?? null)).toEqual([7, null, null]);
+  });
+
+  it("pads a short top_8 with nulls and ignores rows for unknown race ids", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("sprint_predictions", {
+      data: [
+        {
+          race_id: 501,
+          status: "submitted",
+          sprint_pole_driver_id: null,
+          qualifying_top_3: [101, 102, 103],
+          top_8: [101, 102],
+          fastest_lap_driver_id: null,
+          points_earned: null,
+        },
+        {
+          race_id: 999, // not in the season's races
+          status: "scored",
+          sprint_pole_driver_id: 101,
+          qualifying_top_3: [101],
+          top_8: [101],
+          fastest_lap_driver_id: 101,
+          points_earned: 50,
+        },
+      ],
+      error: null,
+    });
+
+    const races = [makeRace(9001, 1), makeRace(9002, 2)];
+    const [first, second] = await fetchUserSprintPredictions(supabase, USER_ID, races);
+
+    expect(first.sprintWinner?.driverNumber).toBe(1);
+    expect(first.restOfTop8.map((d) => d?.driverNumber ?? null)).toEqual([
+      2, null, null, null, null, null, null,
+    ]);
+    expect(second.status).toBe("pending");
+    expect(second.pointsEarned).toBeNull();
+  });
+
+  it("reuses a passed-in context without re-querying the season mappings", async () => {
+    const { supabase, mockTable } = setupBase();
+    const ctx = await createPredictionContext(supabase);
+    // From here on, only sprint_predictions should be consumed.
+    mockTable("sprint_predictions", { data: null, error: null });
+    // Poison the mapping queues: if the context were rebuilt, drivers/races
+    // would resolve to empty and the mapping below would fail.
+    mockTable("seasons", { data: null, error: null });
+    mockTable("drivers", { data: null, error: null });
+    mockTable("races", { data: null, error: null });
+
+    const [prediction] = await fetchUserSprintPredictions(
+      supabase,
+      USER_ID,
+      [makeRace(9001, 1)],
+      ctx
+    );
+    expect(prediction.raceId).toBe(9001);
+    expect(prediction.status).toBe("pending");
+  });
+});

--- a/apps/web/app/race-prediction/page.tsx
+++ b/apps/web/app/race-prediction/page.tsx
@@ -5,18 +5,14 @@ import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import { RacePredictionContent } from "@/components/predictions/RacePredictionContent";
 import { fetchRacesFromDb } from "@/lib/races";
-import { fetchDriversFromDb } from "@/lib/drivers";
 import { fetchTeamsFromDb, fetchTeamsWithDrivers } from "@/lib/teams";
-import type {
-  FullRacePrediction,
-  SprintPrediction,
-  ChampionPrediction,
-  RaceResult,
-  SprintResult,
-  Driver,
-  TeamBestDriverPrediction,
-  SeasonAwardPrediction,
-} from "@f1/shared/types";
+import {
+  createPredictionContext,
+  fetchUserRacePredictions,
+  fetchUserSprintPredictions,
+} from "@f1/shared/lib/predictions";
+import { fetchChampionPredictionData } from "@f1/shared/lib/champion-predictions";
+import { fetchRaceResults, fetchSprintResults } from "@f1/shared/lib/results";
 
 interface PageProps {
   searchParams: Promise<{ user?: string; round?: string; tab?: string }>;
@@ -66,42 +62,16 @@ export default async function RacePredictionPage({ searchParams }: PageProps) {
     viewingDisplayName = viewingProfile?.display_name ?? "Driver";
   }
 
-  // Fetch current season dynamically
-  const { data: currentSeason } = await supabase
-    .from("seasons")
-    .select("id")
-    .eq("is_current", true)
-    .single();
-
-  const seasonId = currentSeason?.id;
-  if (!seasonId) {
+  // Season-scoped lookup context (current season + driver/race id mappings),
+  // shared by every prediction/result fetcher below so the mappings are only
+  // queried once.
+  const predictionContext = await createPredictionContext(supabase);
+  if (!predictionContext) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <p className="text-muted">No active season found.</p>
       </div>
     );
-  }
-
-  // Build mapping: DB driver ID -> driver number (for converting DB data to frontend)
-  const { data: dbDrivers } = await supabase
-    .from("drivers")
-    .select("id, driver_number")
-    .eq("season_id", seasonId);
-
-  const driverIdToNumber = new Map<number, number>();
-  for (const d of dbDrivers ?? []) {
-    driverIdToNumber.set(d.id, d.driver_number);
-  }
-
-  // Build mapping: DB race ID -> meeting key
-  const { data: dbRaces } = await supabase
-    .from("races")
-    .select("id, meeting_key")
-    .eq("season_id", seasonId);
-
-  const raceIdToMeetingKey = new Map<number, number>();
-  for (const r of dbRaces ?? []) {
-    raceIdToMeetingKey.set(r.id, r.meeting_key);
   }
 
   // Fetch races with live DB datetimes
@@ -122,253 +92,33 @@ export default async function RacePredictionPage({ searchParams }: PageProps) {
     );
   }
 
-  // Fetch drivers and teams from DB
-  const allDrivers = await fetchDriversFromDb();
+  // Fetch drivers (already resolved inside the shared context) and teams
+  const allDrivers = predictionContext.allDrivers;
   const allTeams = await fetchTeamsFromDb();
   const teamsWithDrivers = await fetchTeamsWithDrivers();
 
-  function findDriver(dbDriverId: number | null): Driver | null {
-    if (!dbDriverId) return null;
-    const driverNumber = driverIdToNumber.get(dbDriverId);
-    if (driverNumber === undefined) return null;
-    return allDrivers.find((d) => d.driverNumber === driverNumber) ?? null;
-  }
-
-  // Fetch race predictions for the target user
-  const { data: racePredRows } = await supabase
-    .from("race_predictions")
-    .select("race_id, status, pole_position_driver_id, qualifying_top_3, top_10, fastest_lap_driver_id, fastest_pit_stop_driver_id, driver_of_the_day_driver_id, points_earned")
-    .eq("user_id", viewingUserId);
-
-  const racePredByMeetingKey = new Map<number, (typeof racePredRows extends (infer T)[] | null ? T : never)>();
-  for (const row of racePredRows ?? []) {
-    const meetingKey = raceIdToMeetingKey.get(row.race_id);
-    if (meetingKey !== undefined) {
-      racePredByMeetingKey.set(meetingKey, row);
-    }
-  }
-
-  // Build a 3-slot qualifying-top-3 (Driver | null)[] from the stored array,
-  // falling back to the legacy single pole column for not-yet-backfilled rows.
-  function buildQualifyingTop3(
-    qualifyingTop3Ids: (number | null)[] | null | undefined,
-    legacyPoleId: number | null | undefined
-  ): (Driver | null)[] {
-    const ids: (number | null)[] =
-      qualifyingTop3Ids && qualifyingTop3Ids.length > 0
-        ? qualifyingTop3Ids
-        : legacyPoleId != null
-          ? [legacyPoleId]
-          : [];
-    return Array.from({ length: 3 }, (_, i) => findDriver(ids[i] ?? null));
-  }
-
-  const predictions: FullRacePrediction[] = RACES.map((race) => {
-    const row = racePredByMeetingKey.get(race.meetingKey);
-    const top10Ids: (number | null)[] = row?.top_10 ?? [];
-    return {
-      raceId: race.meetingKey,
-      userId: viewingUserId,
-      status: row?.status ?? "pending",
-      qualifyingTop3: buildQualifyingTop3(row?.qualifying_top_3, row?.pole_position_driver_id),
-      raceWinner: findDriver(top10Ids[0] ?? null),
-      restOfTop10: Array.from({ length: 9 }, (_, i) => findDriver(top10Ids[i + 1] ?? null)),
-      fastestLap: findDriver(row?.fastest_lap_driver_id ?? null),
-      fastestPitStop: findDriver(row?.fastest_pit_stop_driver_id ?? null),
-      driverOfTheDay: findDriver(row?.driver_of_the_day_driver_id ?? null),
-      pointsEarned: row?.points_earned ?? null,
-    };
-  });
-
-  // Fetch sprint predictions
-  const { data: sprintPredRows } = await supabase
-    .from("sprint_predictions")
-    .select("race_id, status, sprint_pole_driver_id, qualifying_top_3, top_8, fastest_lap_driver_id, points_earned")
-    .eq("user_id", viewingUserId);
-
-  const sprintPredByMeetingKey = new Map<number, (typeof sprintPredRows extends (infer T)[] | null ? T : never)>();
-  for (const row of sprintPredRows ?? []) {
-    const meetingKey = raceIdToMeetingKey.get(row.race_id);
-    if (meetingKey !== undefined) {
-      sprintPredByMeetingKey.set(meetingKey, row);
-    }
-  }
-
-  const sprintRaces = RACES.filter((r) => r.hasSprint);
-  const sprintPredictions: SprintPrediction[] = sprintRaces.map((race) => {
-    const row = sprintPredByMeetingKey.get(race.meetingKey);
-    const top8Ids: (number | null)[] = row?.top_8 ?? [];
-    return {
-      raceId: race.meetingKey,
-      userId: viewingUserId,
-      status: row?.status ?? "pending",
-      qualifyingTop3: buildQualifyingTop3(row?.qualifying_top_3, row?.sprint_pole_driver_id),
-      sprintWinner: findDriver(top8Ids[0] ?? null),
-      restOfTop8: Array.from({ length: 7 }, (_, i) => findDriver(top8Ids[i + 1] ?? null)),
-      fastestLap: findDriver(row?.fastest_lap_driver_id ?? null),
-      pointsEarned: row?.points_earned ?? null,
-    };
-  });
-
-  // Fetch season award predictions (unified champion + team best driver)
-  const { data: seasonAwardRows } = await supabase
-    .from("season_award_predictions")
-    .select("id, award_type_id, driver_id, team_id, is_half_points, status, points_earned, season_award_types(slug, name, subject_type, scope_team_id, points_value, sort_order)")
-    .eq("user_id", viewingUserId)
-    .eq("season_id", seasonId);
-
-  const seasonAwardPredictions: SeasonAwardPrediction[] = (seasonAwardRows ?? []).map((row) => {
-    const rawAwardType = row.season_award_types;
-    const awardType = (Array.isArray(rawAwardType) ? rawAwardType[0] : rawAwardType) as { slug: string; name: string; subject_type: string; scope_team_id: number | null; points_value: number; sort_order: number } | null;
-    return {
-      id: row.id,
-      awardTypeId: row.award_type_id,
-      slug: awardType?.slug ?? "",
-      name: awardType?.name ?? "",
-      subjectType: (awardType?.subject_type ?? "driver") as "driver" | "team",
-      scopeTeamId: awardType?.scope_team_id ?? null,
-      pointsValue: awardType?.points_value ?? 0,
-      driverId: row.driver_id,
-      teamId: row.team_id,
-      isHalfPoints: row.is_half_points ?? false,
-      status: row.status ?? "pending",
-      pointsEarned: row.points_earned ?? 0,
-    };
-  });
-
-  // Build legacy ChampionPrediction from season award data
-  const awardBySlug = new Map(seasonAwardPredictions.map((p) => [p.slug, p]));
-  const wdcAward = awardBySlug.get("wdc");
-  const wccAward = awardBySlug.get("wcc");
-  const mostDnfsAward = awardBySlug.get("most_dnfs");
-  const mostPodiumsAward = awardBySlug.get("most_podiums");
-  const mostWinsAward = awardBySlug.get("most_wins");
-
-  let wccTeamName: string | null = null;
-  if (wccAward?.teamId) {
-    const { data: teamRow } = await supabase
-      .from("teams")
-      .select("name")
-      .eq("id", wccAward.teamId)
-      .single();
-    wccTeamName = teamRow?.name ?? null;
-  }
-
-  // Determine overall champion status from individual awards
-  const championAwards = [wdcAward, wccAward, mostDnfsAward, mostPodiumsAward, mostWinsAward];
-  const hasAnyChampionSubmitted = championAwards.some((a) => a?.status === "submitted" || a?.status === "scored");
-  const hasAnyChampionScored = championAwards.some((a) => a?.status === "scored");
-  const anyHalfPoints = championAwards.some((a) => a?.isHalfPoints);
-
-  const championPrediction: ChampionPrediction = {
-    userId: viewingUserId,
-    status: hasAnyChampionScored ? "scored" : hasAnyChampionSubmitted ? "submitted" : "pending",
-    wdcWinner: findDriver(wdcAward?.driverId ?? null),
-    wccWinner: wccTeamName,
-    mostDnfsDriver: findDriver(mostDnfsAward?.driverId ?? null),
-    mostPodiumsDriver: findDriver(mostPodiumsAward?.driverId ?? null),
-    mostWinsDriver: findDriver(mostWinsAward?.driverId ?? null),
-    pointsEarned: championAwards.reduce((sum, a) => sum + (a?.pointsEarned ?? 0), 0),
-    wdcPoints: wdcAward?.pointsEarned ?? 0,
-    wccPoints: wccAward?.pointsEarned ?? 0,
-    mostDnfsPoints: mostDnfsAward?.pointsEarned ?? 0,
-    mostPodiumsPoints: mostPodiumsAward?.pointsEarned ?? 0,
-    mostWinsPoints: mostWinsAward?.pointsEarned ?? 0,
-    isHalfPoints: anyHalfPoints,
-  };
-
-  // Build legacy TeamBestDriverPrediction[] from season award data
-  const teamBestDriverPredictions: TeamBestDriverPrediction[] = teamsWithDrivers.map((team) => {
-    const award = awardBySlug.get(`best_driver_${team.id}`);
-    const driverId = award?.driverId ?? null;
-    const matchedDriver = driverId ? team.drivers.find((d) => d.id === driverId) : null;
-    return {
-      teamId: team.id,
-      teamName: team.name,
-      teamColor: team.color,
-      driverId,
-      driverNumber: matchedDriver?.driverNumber ?? null,
-      isHalfPoints: award?.isHalfPoints ?? false,
-      status: award?.status ?? "pending",
-      pointsEarned: award?.pointsEarned ?? 0,
-    };
-  });
-
-  // Fetch race results (same for all users)
-  // Build a qualifying-top-3 (Driver[]) result array, falling back to the
-  // legacy single pole column for not-yet-backfilled rows.
-  function buildResultQualifyingTop3(
-    qualifyingTop3Ids: (number | null)[] | null | undefined,
-    legacyPoleId: number | null | undefined
-  ): Driver[] {
-    const ids: (number | null)[] =
-      qualifyingTop3Ids && qualifyingTop3Ids.length > 0
-        ? qualifyingTop3Ids
-        : legacyPoleId != null
-          ? [legacyPoleId]
-          : [];
-    return ids.map((id) => findDriver(id ?? null)).filter((d): d is Driver => d !== null);
-  }
-
-  const { data: raceResultRows } = await supabase
-    .from("race_results")
-    .select("race_id, pole_position_driver_id, qualifying_top_3, qualifying_p4_driver_id, top_10, p11_driver_id, fastest_lap_driver_id, fastest_pit_stop_driver_id, driver_of_the_day_driver_id");
-
-  const raceResults: Record<number, RaceResult> = {};
-  for (const row of raceResultRows ?? []) {
-    const meetingKey = raceIdToMeetingKey.get(row.race_id);
-    if (meetingKey === undefined) continue;
-
-    const top10Ids: number[] = row.top_10 ?? [];
-    const top10 = top10Ids.map((id) => findDriver(id)).filter((d): d is Driver => d !== null);
-    const qualifyingTop3 = buildResultQualifyingTop3(row.qualifying_top_3, row.pole_position_driver_id);
-    const qualifyingP4 = findDriver(row.qualifying_p4_driver_id ?? null);
-    const p11 = findDriver(row.p11_driver_id ?? null);
-    const fastestLap = findDriver(row.fastest_lap_driver_id);
-    const fastestPit = findDriver(row.fastest_pit_stop_driver_id);
-    const driverOfTheDay = findDriver(row.driver_of_the_day_driver_id);
-    if (top10.length > 0 && qualifyingTop3[0] && fastestLap) {
-      raceResults[meetingKey] = {
-        raceId: meetingKey,
-        qualifyingTop3,
-        raceWinner: top10[0],
-        top10,
-        fastestLap,
-        ...(qualifyingP4 ? { qualifyingP4 } : {}),
-        ...(p11 ? { p11 } : {}),
-        ...(fastestPit ? { fastestPitStop: fastestPit } : {}),
-        ...(driverOfTheDay ? { driverOfTheDay } : {}),
-      };
-    }
-  }
-
-  const { data: sprintResultRows } = await supabase
-    .from("sprint_results")
-    .select("race_id, sprint_pole_driver_id, qualifying_top_3, qualifying_p4_driver_id, top_8, p9_driver_id, fastest_lap_driver_id");
-
-  const sprintResults: Record<number, SprintResult> = {};
-  for (const row of sprintResultRows ?? []) {
-    const meetingKey = raceIdToMeetingKey.get(row.race_id);
-    if (meetingKey === undefined) continue;
-
-    const top8Ids: number[] = row.top_8 ?? [];
-    const top8 = top8Ids.map((id) => findDriver(id)).filter((d): d is Driver => d !== null);
-    const qualifyingTop3 = buildResultQualifyingTop3(row.qualifying_top_3, row.sprint_pole_driver_id);
-    const qualifyingP4 = findDriver(row.qualifying_p4_driver_id ?? null);
-    const p9 = findDriver(row.p9_driver_id ?? null);
-    const fastestLap = findDriver(row.fastest_lap_driver_id);
-    if (top8.length > 0 && qualifyingTop3[0] && fastestLap) {
-      sprintResults[meetingKey] = {
-        raceId: meetingKey,
-        qualifyingTop3,
-        sprintWinner: top8[0],
-        top8,
-        fastestLap,
-        ...(qualifyingP4 ? { qualifyingP4 } : {}),
-        ...(p9 ? { p9 } : {}),
-      };
-    }
-  }
+  // Predictions, champion data and results — all assembled by the shared
+  // fetchers (packages/shared/lib), reusing the one prediction context.
+  const predictions = await fetchUserRacePredictions(
+    supabase,
+    viewingUserId,
+    RACES,
+    predictionContext
+  );
+  const sprintPredictions = await fetchUserSprintPredictions(
+    supabase,
+    viewingUserId,
+    RACES,
+    predictionContext
+  );
+  const { championPrediction, teamBestDriverPredictions } = await fetchChampionPredictionData(
+    supabase,
+    viewingUserId,
+    teamsWithDrivers,
+    predictionContext
+  );
+  const raceResults = await fetchRaceResults(supabase, predictionContext);
+  const sprintResults = await fetchSprintResults(supabase, predictionContext);
 
   // Determine initial race index: use round param if provided, otherwise next upcoming race
   const now = new Date();

--- a/apps/web/components/predictions/RacePredictionContent.tsx
+++ b/apps/web/components/predictions/RacePredictionContent.tsx
@@ -43,27 +43,17 @@ import {
   type RaceFieldPoints,
   type SprintFieldPoints,
 } from "@f1/shared/lib/scoring";
-import { proximityStatus, type MatchStatus } from "@f1/shared/lib/prediction-status";
+import {
+  computeRaceMatchStatuses,
+  computeSprintMatchStatuses,
+  type MatchStatus,
+  type RaceMatchStatuses,
+  type SprintMatchStatuses,
+} from "@f1/shared/lib/prediction-status";
 import { DriverSelect } from "./DriverSelect";
 import { useLanguage } from "@/components/providers/LanguageProvider";
 
 type TabMode = "race" | "sprint" | "champion";
-
-interface RaceMatchStatuses {
-  qualifyingTop3: MatchStatus[];
-  raceWinner: MatchStatus;
-  restOfTop10: MatchStatus[];
-  fastestLap: MatchStatus;
-  fastestPitStop: MatchStatus;
-  driverOfTheDay: MatchStatus;
-}
-
-interface SprintMatchStatuses {
-  qualifyingTop3: MatchStatus[];
-  sprintWinner: MatchStatus;
-  restOfTop8: MatchStatus[];
-  fastestLap: MatchStatus;
-}
 
 interface RacePredictionContentProps {
   races: Race[];
@@ -499,38 +489,7 @@ export function RacePredictionContent({
 
   const raceMatchStatuses = useMemo((): RaceMatchStatuses | null => {
     if (!currentResult || !currentPrediction) return null;
-
-    function fieldStatus(predicted: Driver | null, actual: Driver): MatchStatus {
-      if (!predicted) return null;
-      if (predicted.driverNumber === actual.driverNumber) return "exact";
-      return null;
-    }
-
-    // Top-10 (P1 winner + P2..P10): driver-based ±1 proximity, P11 boundary.
-    const top10Status = (predicted: Driver | null, slotIndex: number): MatchStatus =>
-      proximityStatus(predicted, currentResult.top10, currentResult.p11 ?? null, 10, slotIndex);
-
-    const restStatuses: MatchStatus[] = currentPrediction.restOfTop10.map((predicted, i) =>
-      top10Status(predicted, i + 1)
-    );
-
-    // Qualifying top-3 (Q1..Q3): driver-based ±1 proximity, Q4 boundary.
-    const qualifyingStatuses: MatchStatus[] = currentPrediction.qualifyingTop3.map((predicted, i) =>
-      proximityStatus(predicted, currentResult.qualifyingTop3, currentResult.qualifyingP4 ?? null, 3, i)
-    );
-
-    return {
-      qualifyingTop3: qualifyingStatuses,
-      raceWinner: top10Status(currentPrediction.raceWinner, 0),
-      restOfTop10: restStatuses,
-      fastestLap: fieldStatus(currentPrediction.fastestLap, currentResult.fastestLap),
-      fastestPitStop: currentResult.fastestPitStop
-        ? fieldStatus(currentPrediction.fastestPitStop, currentResult.fastestPitStop)
-        : null,
-      driverOfTheDay: currentResult.driverOfTheDay
-        ? fieldStatus(currentPrediction.driverOfTheDay, currentResult.driverOfTheDay)
-        : null,
-    };
+    return computeRaceMatchStatuses(currentPrediction, currentResult);
   }, [currentResult, currentPrediction]);
 
   const raceFieldPoints = useMemo((): RaceFieldPoints | null => {
@@ -560,32 +519,7 @@ export function RacePredictionContent({
 
   const sprintMatchStatuses = useMemo((): SprintMatchStatuses | null => {
     if (!currentSprintResult || !currentSprintPred) return null;
-
-    function fieldStatus(predicted: Driver | null, actual: Driver): MatchStatus {
-      if (!predicted) return null;
-      if (predicted.driverNumber === actual.driverNumber) return "exact";
-      return null;
-    }
-
-    // Top-8 (P1 winner + P2..P8): driver-based ±1 proximity, P9 boundary.
-    const top8Status = (predicted: Driver | null, slotIndex: number): MatchStatus =>
-      proximityStatus(predicted, currentSprintResult.top8, currentSprintResult.p9 ?? null, 8, slotIndex);
-
-    const restStatuses: MatchStatus[] = currentSprintPred.restOfTop8.map((predicted, i) =>
-      top8Status(predicted, i + 1)
-    );
-
-    // Sprint qualifying top-3 (Q1..Q3): driver-based ±1 proximity, Q4 boundary.
-    const qualifyingStatuses: MatchStatus[] = currentSprintPred.qualifyingTop3.map((predicted, i) =>
-      proximityStatus(predicted, currentSprintResult.qualifyingTop3, currentSprintResult.qualifyingP4 ?? null, 3, i)
-    );
-
-    return {
-      qualifyingTop3: qualifyingStatuses,
-      sprintWinner: top8Status(currentSprintPred.sprintWinner, 0),
-      restOfTop8: restStatuses,
-      fastestLap: fieldStatus(currentSprintPred.fastestLap, currentSprintResult.fastestLap),
-    };
+    return computeSprintMatchStatuses(currentSprintPred, currentSprintResult);
   }, [currentSprintResult, currentSprintPred]);
 
   const sprintFieldPoints = useMemo((): SprintFieldPoints | null => {

--- a/docs/mobile-migration/decisions.md
+++ b/docs/mobile-migration/decisions.md
@@ -2,6 +2,37 @@
 
 Running record of decisions made after the initial plan. Newest first.
 
+## 2026-07-11 — Sprint/champion tabs + results comparison (Phase 3, final iteration)
+
+**Decision:** The mobile Predictions screen hosts a **Race / Sprint / Champion segmented
+control** (`PredictionTabs`) instead of the web's fused round-selector-with-championship-option —
+three same-sized segments are more thumb-friendly than the web's chip + pill arrangement, and the
+round selector row simply hides on the Champion tab. The Sprint segment is disabled ("N/A") on
+non-sprint rounds and switching to a round without a sprint falls back to the Race tab, mirroring
+the web. The WCC pick uses a **team bottom sheet** (`TeamPickerModal`) consistent with the driver
+picker rather than the web's inline dropdown.
+
+**Results comparison:** slot highlights (green exact / amber close ±1), per-field `+N` points,
+and bonus badges reuse the shared `computeRaceMatchStatuses`/`computeSprintMatchStatuses`
+(newly extracted into `packages/shared/lib/prediction-status.ts`) and the existing
+`computeRaceFieldPoints`/`computeSprintFieldPoints`; the official result renders in a
+collapsible `ResultsPanel` behind the same Show/Hide Results toggle as the web.
+
+**Shared extraction:** the race-prediction page's inline assembly moved into shared service
+functions — `fetchUserSprintPredictions` (predictions.ts), `fetchChampionPredictionData`
+(champion-predictions.ts), `fetchRaceResults`/`fetchSprintResults` (results.ts) — all accepting
+an optional season-scoped **`PredictionContext`** (`createPredictionContext`) so the web Server
+Component builds the driver/race id mappings once per request while mobile's per-tab TanStack
+queries call the fetchers standalone. `fetchUserRacePredictions` kept its signature (context is
+an optional 4th arg) and the web page now consumes all of them; behavior is unchanged and covered
+by unit tests (100% lines on the new modules).
+
+**Champion semantics on mobile:** same phase machine as web (`getChampionPredictionPhase`):
+full → info banner, half → half-points banner + amber confirm modal listing the changed fields
+(tracked against the last saved state, like the web's refs), closed → red banner + locked actions.
+Champion submits/reset go through the same `/api/predictions/submit` payloads; champion reset is
+not offered (web hides it too).
+
 ## 2026-07-11 — Leaderboard + Standings screens with a bottom tab navigator (Phase 3)
 
 **Decision:** `apps/mobile/src/app/(app)/_layout.tsx` switched from a Stack to an Expo Router

--- a/docs/mobile-migration/mobile-migration-plan.md
+++ b/docs/mobile-migration/mobile-migration-plan.md
@@ -9,7 +9,9 @@
 > | 1 — Mobile scaffold | ✅ Done (PR #82, 2026-07-08 — Expo SDK 54) |
 > | 2 — Auth | ✅ Done (PR #84, 2026-07-10 — email/password + Google; **Apple sign-in deferred**, see decisions.md) |
 > | 3 — Core loop | ✅ Code complete (pending device verification). Race prediction screen (PR #85, 2026-07-11 — incl. Bearer-token API auth). Leaderboard + standings screens (PR #86, 2026-07-11 — incl. bottom tab navigator + shared `fetchDetailedLeaderboard` extraction). Sprint + champion tabs and the results-comparison display (2026-07-11 — incl. shared sprint/champion/results fetcher extractions, see decisions.md). **Next:** verify the new tabs in Expo Go on-device, then Phase 4 |
-> | 4 — Full dashboard parity | ⬜ Not started |
+> | 4a — Home dashboard screen | ⬜ Not started |
+> | 4b — Achievements screen | ⬜ Not started |
+> | 4c — Profile & account settings | ⬜ Not started |
 > | 5 — Ship (EAS Submit) | ⬜ Not started |
 > **Stack:** React Native + Expo (developer is on Windows, learning RN/Expo via a course
 > that covers Expo Router, NativeWind, TanStack Query, EAS Build + Publish).
@@ -116,8 +118,45 @@ leaderboards, standings — one source of truth).
 - Leaderboard + Standings (direct-Supabase reads, low effort, high daily value).
 
 ### Phase 4 — Full dashboard parity
-- All 12 dashboard cards + modals (PointSystem, RaceCalendar, Standings).
-- Achievements + Profile.
+
+Split into three shippable iterations, highest daily value first, with the trickiest native
+integration (avatar upload) landing last. Each iteration is its own branch + PR, follows the
+established shared-extraction pattern (a service function in `packages/shared/lib/` that both
+apps consume — as with `predictions.ts`/`leaderboard.ts`), and must clear every quality gate
+plus on-device Expo Go verification before the next begins. Leaderboard and Standings already
+ship as their own tabs (Phase 3), so on the dashboard their cards are summaries that deep-link
+into those existing screens rather than re-implementations.
+
+#### Phase 4a — Home dashboard screen
+Replace the placeholder Home tab with the real dashboard (web `app/page.tsx` bento grid):
+- **UserSummaryCard** — total points, rank/total users, achievements-earned progress.
+- **NextRaceCountdown** / **NoUpcomingRaces** — next race + live countdown.
+- **StandingsCard** + **LeaderboardCard** — compact summaries that navigate to the existing
+  Standings / Leaderboard tabs.
+- **PointSystemCard** → **PointSystemModal** as a bottom sheet / detail screen.
+- **RaceCalendarCard** → **RaceCalendarModal** as a bottom sheet / detail screen (per-race
+  prediction status, reusing the shared `getRaceCalendarEntries`).
+- **NewPointsSystemBanner** announcement.
+- Extract the dashboard data assembly currently inline in `app/page.tsx` (ranked leaderboard
+  slice, user stats, per-race prediction status, calendar entries) into a shared fetcher and
+  have web consume it — several pieces overlap `fetchDetailedLeaderboard` and the prediction
+  fetchers already extracted.
+
+#### Phase 4b — Achievements screen
+- Category-filtered grid (predictions / accuracy / milestones / special + "all"), earned vs
+  locked states, per-achievement progress bars (web `AchievementsContent`).
+- Reads through the shared achievements module (`fetchAchievementsData` /
+  `achievement-calculator.ts`); the lucide icon map stays web-only, so mobile supplies its own
+  icon mapping over the shared achievement ids/categories.
+
+#### Phase 4c — Profile & account settings
+- Stats header (points, rank, predictions, achievements), display-name inline edit, language
+  toggle, sign out, and the account-sensitive flows: password change and account deletion
+  (confirmation modals; deletion routes through the Next.js API, never a client-side privileged
+  op).
+- **Avatar upload** — the one genuinely new native surface: `expo-image-picker` →
+  Supabase Storage. Landed last on purpose; needs permissions handling and a dev-build check
+  (works in Expo Go, but verify the picker + upload round-trip on-device early in the iteration).
 
 ### Phase 5 — Ship
 - EAS Submit → App Store + Play Store.

--- a/docs/mobile-migration/mobile-migration-plan.md
+++ b/docs/mobile-migration/mobile-migration-plan.md
@@ -8,7 +8,7 @@
 > | 0 — Monorepo restructure | ✅ Done (PR #81, 2026-07-08) |
 > | 1 — Mobile scaffold | ✅ Done (PR #82, 2026-07-08 — Expo SDK 54) |
 > | 2 — Auth | ✅ Done (PR #84, 2026-07-10 — email/password + Google; **Apple sign-in deferred**, see decisions.md) |
-> | 3 — Core loop | 🔄 Race prediction screen done (PR #85, 2026-07-11 — incl. Bearer-token API auth). Leaderboard + standings screens done (PR #86, 2026-07-11 — incl. bottom tab navigator + shared `fetchDetailedLeaderboard` extraction). **Next:** sprint/champion tabs + results-comparison display |
+> | 3 — Core loop | ✅ Code complete (pending device verification). Race prediction screen (PR #85, 2026-07-11 — incl. Bearer-token API auth). Leaderboard + standings screens (PR #86, 2026-07-11 — incl. bottom tab navigator + shared `fetchDetailedLeaderboard` extraction). Sprint + champion tabs and the results-comparison display (2026-07-11 — incl. shared sprint/champion/results fetcher extractions, see decisions.md). **Next:** verify the new tabs in Expo Go on-device, then Phase 4 |
 > | 4 — Full dashboard parity | ⬜ Not started |
 > | 5 — Ship (EAS Submit) | ⬜ Not started |
 > **Stack:** React Native + Expo (developer is on Windows, learning RN/Expo via a course

--- a/packages/shared/lib/champion-predictions.ts
+++ b/packages/shared/lib/champion-predictions.ts
@@ -1,0 +1,171 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  ChampionPrediction,
+  SeasonAwardPrediction,
+  TeamBestDriverPrediction,
+  TeamWithDrivers,
+} from "../types";
+import { createPredictionContext, type PredictionContext } from "./predictions";
+
+/** Everything the champion tab needs, assembled from season award rows. */
+export interface ChampionPredictionData {
+  seasonAwardPredictions: SeasonAwardPrediction[];
+  championPrediction: ChampionPrediction;
+  teamBestDriverPredictions: TeamBestDriverPrediction[];
+}
+
+/** Empty champion prediction used when nothing is stored yet (or no season). */
+function emptyChampionPrediction(userId: string): ChampionPrediction {
+  return {
+    userId,
+    status: "pending",
+    wdcWinner: null,
+    wccWinner: null,
+    mostDnfsDriver: null,
+    mostPodiumsDriver: null,
+    mostWinsDriver: null,
+    pointsEarned: 0,
+    wdcPoints: 0,
+    wccPoints: 0,
+    mostDnfsPoints: 0,
+    mostPodiumsPoints: 0,
+    mostWinsPoints: 0,
+    isHalfPoints: false,
+  };
+}
+
+/**
+ * Fetches a user's season award predictions (the unified champion + team best
+ * driver rows) for the current season and assembles them into the legacy
+ * `ChampionPrediction` + `TeamBestDriverPrediction[]` shapes the prediction
+ * UI consumes.
+ *
+ * `teamsWithDrivers` is passed in (already fetched via `fetchTeamsWithDrivers`)
+ * so teams aren't queried twice. The caller injects the Supabase client (and,
+ * optionally, a pre-built `PredictionContext`). Returns empty/pending
+ * placeholders when there is no current season.
+ */
+export async function fetchChampionPredictionData(
+  supabase: SupabaseClient,
+  userId: string,
+  teamsWithDrivers: TeamWithDrivers[],
+  context?: PredictionContext | null
+): Promise<ChampionPredictionData> {
+  const emptyTeamBest: TeamBestDriverPrediction[] = teamsWithDrivers.map((team) => ({
+    teamId: team.id,
+    teamName: team.name,
+    teamColor: team.color,
+    driverId: null,
+    driverNumber: null,
+    isHalfPoints: false,
+    status: "pending",
+    pointsEarned: 0,
+  }));
+
+  const ctx = context ?? (await createPredictionContext(supabase));
+  if (!ctx) {
+    return {
+      seasonAwardPredictions: [],
+      championPrediction: emptyChampionPrediction(userId),
+      teamBestDriverPredictions: emptyTeamBest,
+    };
+  }
+  const { seasonId, findDriver } = ctx;
+
+  // Season award prediction rows (unified champion + team best driver)
+  const { data: seasonAwardRows } = await supabase
+    .from("season_award_predictions")
+    .select(
+      "id, award_type_id, driver_id, team_id, is_half_points, status, points_earned, season_award_types(slug, name, subject_type, scope_team_id, points_value, sort_order)"
+    )
+    .eq("user_id", userId)
+    .eq("season_id", seasonId);
+
+  const seasonAwardPredictions: SeasonAwardPrediction[] = (seasonAwardRows ?? []).map((row) => {
+    const rawAwardType = row.season_award_types;
+    const awardType = (Array.isArray(rawAwardType) ? rawAwardType[0] : rawAwardType) as {
+      slug: string;
+      name: string;
+      subject_type: string;
+      scope_team_id: number | null;
+      points_value: number;
+      sort_order: number;
+    } | null;
+    return {
+      id: row.id,
+      awardTypeId: row.award_type_id,
+      slug: awardType?.slug ?? "",
+      name: awardType?.name ?? "",
+      subjectType: (awardType?.subject_type ?? "driver") as "driver" | "team",
+      scopeTeamId: awardType?.scope_team_id ?? null,
+      pointsValue: awardType?.points_value ?? 0,
+      driverId: row.driver_id,
+      teamId: row.team_id,
+      isHalfPoints: row.is_half_points ?? false,
+      status: row.status ?? "pending",
+      pointsEarned: row.points_earned ?? 0,
+    };
+  });
+
+  // Build the legacy ChampionPrediction from the season award rows
+  const awardBySlug = new Map(seasonAwardPredictions.map((p) => [p.slug, p]));
+  const wdcAward = awardBySlug.get("wdc");
+  const wccAward = awardBySlug.get("wcc");
+  const mostDnfsAward = awardBySlug.get("most_dnfs");
+  const mostPodiumsAward = awardBySlug.get("most_podiums");
+  const mostWinsAward = awardBySlug.get("most_wins");
+
+  let wccTeamName: string | null = null;
+  if (wccAward?.teamId) {
+    const { data: teamRow } = await supabase
+      .from("teams")
+      .select("name")
+      .eq("id", wccAward.teamId)
+      .single();
+    wccTeamName = teamRow?.name ?? null;
+  }
+
+  // Determine overall champion status from the individual awards
+  const championAwards = [wdcAward, wccAward, mostDnfsAward, mostPodiumsAward, mostWinsAward];
+  const hasAnyChampionSubmitted = championAwards.some(
+    (a) => a?.status === "submitted" || a?.status === "scored"
+  );
+  const hasAnyChampionScored = championAwards.some((a) => a?.status === "scored");
+  const anyHalfPoints = championAwards.some((a) => a?.isHalfPoints);
+
+  const championPrediction: ChampionPrediction = {
+    userId,
+    status: hasAnyChampionScored ? "scored" : hasAnyChampionSubmitted ? "submitted" : "pending",
+    wdcWinner: findDriver(wdcAward?.driverId ?? null),
+    wccWinner: wccTeamName,
+    mostDnfsDriver: findDriver(mostDnfsAward?.driverId ?? null),
+    mostPodiumsDriver: findDriver(mostPodiumsAward?.driverId ?? null),
+    mostWinsDriver: findDriver(mostWinsAward?.driverId ?? null),
+    pointsEarned: championAwards.reduce((sum, a) => sum + (a?.pointsEarned ?? 0), 0),
+    wdcPoints: wdcAward?.pointsEarned ?? 0,
+    wccPoints: wccAward?.pointsEarned ?? 0,
+    mostDnfsPoints: mostDnfsAward?.pointsEarned ?? 0,
+    mostPodiumsPoints: mostPodiumsAward?.pointsEarned ?? 0,
+    mostWinsPoints: mostWinsAward?.pointsEarned ?? 0,
+    isHalfPoints: anyHalfPoints,
+  };
+
+  // Build the legacy TeamBestDriverPrediction[] from the season award rows
+  const teamBestDriverPredictions: TeamBestDriverPrediction[] = teamsWithDrivers.map((team) => {
+    const award = awardBySlug.get(`best_driver_${team.id}`);
+    const driverId = award?.driverId ?? null;
+    const matchedDriver = driverId ? team.drivers.find((d) => d.id === driverId) : null;
+    return {
+      teamId: team.id,
+      teamName: team.name,
+      teamColor: team.color,
+      driverId,
+      driverNumber: matchedDriver?.driverNumber ?? null,
+      isHalfPoints: award?.isHalfPoints ?? false,
+      status: award?.status ?? "pending",
+      pointsEarned: award?.pointsEarned ?? 0,
+    };
+  });
+
+  return { seasonAwardPredictions, championPrediction, teamBestDriverPredictions };
+}

--- a/packages/shared/lib/prediction-status.ts
+++ b/packages/shared/lib/prediction-status.ts
@@ -1,4 +1,10 @@
-import type { Driver } from "../types";
+import type {
+  Driver,
+  FullRacePrediction,
+  RaceResult,
+  SprintPrediction,
+  SprintResult,
+} from "../types";
 
 /** Per-slot prediction match status once a result is known. */
 export type MatchStatus = "exact" | "close" | "miss" | null;
@@ -31,4 +37,80 @@ export function proximityStatus(
   if (delta === 0) return "exact";
   if (delta === 1) return "close";
   return "miss";
+}
+
+/** Per-slot match statuses for a race prediction vs the race result. */
+export interface RaceMatchStatuses {
+  qualifyingTop3: MatchStatus[];
+  raceWinner: MatchStatus;
+  restOfTop10: MatchStatus[];
+  fastestLap: MatchStatus;
+  fastestPitStop: MatchStatus;
+  driverOfTheDay: MatchStatus;
+}
+
+/** Per-slot match statuses for a sprint prediction vs the sprint result. */
+export interface SprintMatchStatuses {
+  qualifyingTop3: MatchStatus[];
+  sprintWinner: MatchStatus;
+  restOfTop8: MatchStatus[];
+  fastestLap: MatchStatus;
+}
+
+/** Exact-only status for single-driver special fields (no proximity). */
+function specialFieldStatus(predicted: Driver | null, actual: Driver): MatchStatus {
+  if (!predicted) return null;
+  if (predicted.driverNumber === actual.driverNumber) return "exact";
+  return null;
+}
+
+/**
+ * Computes the per-slot match statuses of a race prediction against the race
+ * result: driver-based ±1 proximity for the top-10 (P11 boundary) and
+ * qualifying top-3 (Q4 boundary); exact-only for the special fields, which
+ * stay `null` when the result doesn't include that field.
+ */
+export function computeRaceMatchStatuses(
+  prediction: FullRacePrediction,
+  result: RaceResult
+): RaceMatchStatuses {
+  const top10Status = (predicted: Driver | null, slotIndex: number): MatchStatus =>
+    proximityStatus(predicted, result.top10, result.p11 ?? null, 10, slotIndex);
+
+  return {
+    qualifyingTop3: prediction.qualifyingTop3.map((predicted, i) =>
+      proximityStatus(predicted, result.qualifyingTop3, result.qualifyingP4 ?? null, 3, i)
+    ),
+    raceWinner: top10Status(prediction.raceWinner, 0),
+    restOfTop10: prediction.restOfTop10.map((predicted, i) => top10Status(predicted, i + 1)),
+    fastestLap: specialFieldStatus(prediction.fastestLap, result.fastestLap),
+    fastestPitStop: result.fastestPitStop
+      ? specialFieldStatus(prediction.fastestPitStop, result.fastestPitStop)
+      : null,
+    driverOfTheDay: result.driverOfTheDay
+      ? specialFieldStatus(prediction.driverOfTheDay, result.driverOfTheDay)
+      : null,
+  };
+}
+
+/**
+ * Computes the per-slot match statuses of a sprint prediction against the
+ * sprint result: driver-based ±1 proximity for the top-8 (P9 boundary) and
+ * sprint qualifying top-3 (Q4 boundary); exact-only for the fastest lap.
+ */
+export function computeSprintMatchStatuses(
+  prediction: SprintPrediction,
+  result: SprintResult
+): SprintMatchStatuses {
+  const top8Status = (predicted: Driver | null, slotIndex: number): MatchStatus =>
+    proximityStatus(predicted, result.top8, result.p9 ?? null, 8, slotIndex);
+
+  return {
+    qualifyingTop3: prediction.qualifyingTop3.map((predicted, i) =>
+      proximityStatus(predicted, result.qualifyingTop3, result.qualifyingP4 ?? null, 3, i)
+    ),
+    sprintWinner: top8Status(prediction.sprintWinner, 0),
+    restOfTop8: prediction.restOfTop8.map((predicted, i) => top8Status(predicted, i + 1)),
+    fastestLap: specialFieldStatus(prediction.fastestLap, result.fastestLap),
+  };
 }

--- a/packages/shared/lib/predictions.ts
+++ b/packages/shared/lib/predictions.ts
@@ -1,5 +1,11 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Driver, FullRacePrediction, PredictionStatus, Race } from "../types";
+import type {
+  Driver,
+  FullRacePrediction,
+  PredictionStatus,
+  Race,
+  SprintPrediction,
+} from "../types";
 import { fetchDrivers } from "./drivers";
 
 interface RacePredictionRow {
@@ -14,23 +20,37 @@ interface RacePredictionRow {
   points_earned: number | null;
 }
 
+interface SprintPredictionRow {
+  race_id: number;
+  status: PredictionStatus | null;
+  sprint_pole_driver_id: number | null;
+  qualifying_top_3: (number | null)[] | null;
+  top_8: (number | null)[] | null;
+  fastest_lap_driver_id: number | null;
+  points_earned: number | null;
+}
+
 /**
- * Fetches a user's race predictions for the current season and maps them to
- * one `FullRacePrediction` per passed-in race (keyed by `meetingKey`), with a
- * pending placeholder when the user has no stored prediction for a race.
- *
- * Resolves DB driver ids to full `Driver` objects via the season-scoped
- * driver-number mapping. When `qualifying_top_3` is empty/null it falls back
- * to the legacy single `pole_position_driver_id` column.
- *
- * The caller injects the Supabase client. Returns `[]` when there is no
- * current season.
+ * Season-scoped lookup context shared by every prediction/result fetcher:
+ * resolves DB driver ids to full `Driver` objects and DB race ids to meeting
+ * keys. Build it once per request (web Server Component) and pass it to each
+ * fetcher to avoid re-querying the same mappings; when omitted, each fetcher
+ * builds its own (the idiomatic mobile/TanStack-Query path).
  */
-export async function fetchUserRacePredictions(
-  supabase: SupabaseClient,
-  userId: string,
-  races: Race[]
-): Promise<FullRacePrediction[]> {
+export interface PredictionContext {
+  seasonId: number;
+  raceIdToMeetingKey: Map<number, number>;
+  allDrivers: Driver[];
+  findDriver: (dbDriverId: number | null) => Driver | null;
+}
+
+/**
+ * Builds the season-scoped `PredictionContext` for the current season.
+ * Returns `null` when there is no current season.
+ */
+export async function createPredictionContext(
+  supabase: SupabaseClient
+): Promise<PredictionContext | null> {
   const { data: currentSeason } = await supabase
     .from("seasons")
     .select("id")
@@ -38,7 +58,7 @@ export async function fetchUserRacePredictions(
     .single();
 
   const seasonId = currentSeason?.id;
-  if (!seasonId) return [];
+  if (!seasonId) return null;
 
   // Mapping: DB driver ID -> driver number (season-scoped)
   const { data: dbDrivers } = await supabase
@@ -72,6 +92,51 @@ export async function fetchUserRacePredictions(
     return allDrivers.find((d) => d.driverNumber === driverNumber) ?? null;
   }
 
+  return { seasonId, raceIdToMeetingKey, allDrivers, findDriver };
+}
+
+/**
+ * Builds a 3-slot qualifying-top-3 `(Driver | null)[]` from the stored id
+ * array, falling back to the legacy single pole column for rows that were
+ * never backfilled.
+ */
+export function buildPredictedQualifyingTop3(
+  qualifyingTop3Ids: (number | null)[] | null | undefined,
+  legacyPoleId: number | null | undefined,
+  findDriver: (dbDriverId: number | null) => Driver | null
+): (Driver | null)[] {
+  const ids: (number | null)[] =
+    qualifyingTop3Ids && qualifyingTop3Ids.length > 0
+      ? qualifyingTop3Ids
+      : legacyPoleId != null
+        ? [legacyPoleId]
+        : [];
+  return Array.from({ length: 3 }, (_, i) => findDriver(ids[i] ?? null));
+}
+
+/**
+ * Fetches a user's race predictions for the current season and maps them to
+ * one `FullRacePrediction` per passed-in race (keyed by `meetingKey`), with a
+ * pending placeholder when the user has no stored prediction for a race.
+ *
+ * Resolves DB driver ids to full `Driver` objects via the season-scoped
+ * driver-number mapping. When `qualifying_top_3` is empty/null it falls back
+ * to the legacy single `pole_position_driver_id` column.
+ *
+ * The caller injects the Supabase client (and, optionally, a pre-built
+ * `PredictionContext` so the season mappings are only queried once). Returns
+ * `[]` when there is no current season.
+ */
+export async function fetchUserRacePredictions(
+  supabase: SupabaseClient,
+  userId: string,
+  races: Race[],
+  context?: PredictionContext | null
+): Promise<FullRacePrediction[]> {
+  const ctx = context ?? (await createPredictionContext(supabase));
+  if (!ctx) return [];
+  const { raceIdToMeetingKey, findDriver } = ctx;
+
   // Race prediction rows for the target user
   const { data: racePredRows } = await supabase
     .from("race_predictions")
@@ -88,21 +153,6 @@ export async function fetchUserRacePredictions(
     }
   }
 
-  // Build a 3-slot qualifying-top-3 (Driver | null)[] from the stored array,
-  // falling back to the legacy single pole column for not-yet-backfilled rows.
-  function buildQualifyingTop3(
-    qualifyingTop3Ids: (number | null)[] | null | undefined,
-    legacyPoleId: number | null | undefined
-  ): (Driver | null)[] {
-    const ids: (number | null)[] =
-      qualifyingTop3Ids && qualifyingTop3Ids.length > 0
-        ? qualifyingTop3Ids
-        : legacyPoleId != null
-          ? [legacyPoleId]
-          : [];
-    return Array.from({ length: 3 }, (_, i) => findDriver(ids[i] ?? null));
-  }
-
   return races.map((race) => {
     const row = racePredByMeetingKey.get(race.meetingKey);
     const top10Ids: (number | null)[] = row?.top_10 ?? [];
@@ -110,12 +160,73 @@ export async function fetchUserRacePredictions(
       raceId: race.meetingKey,
       userId,
       status: row?.status ?? "pending",
-      qualifyingTop3: buildQualifyingTop3(row?.qualifying_top_3, row?.pole_position_driver_id),
+      qualifyingTop3: buildPredictedQualifyingTop3(
+        row?.qualifying_top_3,
+        row?.pole_position_driver_id,
+        findDriver
+      ),
       raceWinner: findDriver(top10Ids[0] ?? null),
       restOfTop10: Array.from({ length: 9 }, (_, i) => findDriver(top10Ids[i + 1] ?? null)),
       fastestLap: findDriver(row?.fastest_lap_driver_id ?? null),
       fastestPitStop: findDriver(row?.fastest_pit_stop_driver_id ?? null),
       driverOfTheDay: findDriver(row?.driver_of_the_day_driver_id ?? null),
+      pointsEarned: row?.points_earned ?? null,
+    };
+  });
+}
+
+/**
+ * Fetches a user's sprint predictions for the current season and maps them to
+ * one `SprintPrediction` per passed-in race that has a sprint (keyed by
+ * `meetingKey`), with a pending placeholder when the user has no stored
+ * prediction for a sprint weekend.
+ *
+ * When `qualifying_top_3` is empty/null it falls back to the legacy single
+ * `sprint_pole_driver_id` column. The caller injects the Supabase client
+ * (and, optionally, a pre-built `PredictionContext`). Returns `[]` when there
+ * is no current season.
+ */
+export async function fetchUserSprintPredictions(
+  supabase: SupabaseClient,
+  userId: string,
+  races: Race[],
+  context?: PredictionContext | null
+): Promise<SprintPrediction[]> {
+  const ctx = context ?? (await createPredictionContext(supabase));
+  if (!ctx) return [];
+  const { raceIdToMeetingKey, findDriver } = ctx;
+
+  const { data: sprintPredRows } = await supabase
+    .from("sprint_predictions")
+    .select(
+      "race_id, status, sprint_pole_driver_id, qualifying_top_3, top_8, fastest_lap_driver_id, points_earned"
+    )
+    .eq("user_id", userId);
+
+  const sprintPredByMeetingKey = new Map<number, SprintPredictionRow>();
+  for (const row of (sprintPredRows ?? []) as SprintPredictionRow[]) {
+    const meetingKey = raceIdToMeetingKey.get(row.race_id);
+    if (meetingKey !== undefined) {
+      sprintPredByMeetingKey.set(meetingKey, row);
+    }
+  }
+
+  const sprintRaces = races.filter((r) => r.hasSprint);
+  return sprintRaces.map((race) => {
+    const row = sprintPredByMeetingKey.get(race.meetingKey);
+    const top8Ids: (number | null)[] = row?.top_8 ?? [];
+    return {
+      raceId: race.meetingKey,
+      userId,
+      status: row?.status ?? "pending",
+      qualifyingTop3: buildPredictedQualifyingTop3(
+        row?.qualifying_top_3,
+        row?.sprint_pole_driver_id,
+        findDriver
+      ),
+      sprintWinner: findDriver(top8Ids[0] ?? null),
+      restOfTop8: Array.from({ length: 7 }, (_, i) => findDriver(top8Ids[i + 1] ?? null)),
+      fastestLap: findDriver(row?.fastest_lap_driver_id ?? null),
       pointsEarned: row?.points_earned ?? null,
     };
   });

--- a/packages/shared/lib/results.ts
+++ b/packages/shared/lib/results.ts
@@ -1,0 +1,133 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Driver, RaceResult, SprintResult } from "../types";
+import { createPredictionContext, type PredictionContext } from "./predictions";
+
+/**
+ * Builds a qualifying-top-3 result `Driver[]` from the stored id array,
+ * falling back to the legacy single pole column for rows that were never
+ * backfilled. Unlike the prediction variant, unresolved slots are dropped
+ * (results only contain real drivers).
+ */
+export function buildResultQualifyingTop3(
+  qualifyingTop3Ids: (number | null)[] | null | undefined,
+  legacyPoleId: number | null | undefined,
+  findDriver: (dbDriverId: number | null) => Driver | null
+): Driver[] {
+  const ids: (number | null)[] =
+    qualifyingTop3Ids && qualifyingTop3Ids.length > 0
+      ? qualifyingTop3Ids
+      : legacyPoleId != null
+        ? [legacyPoleId]
+        : [];
+  return ids.map((id) => findDriver(id ?? null)).filter((d): d is Driver => d !== null);
+}
+
+/**
+ * Fetches every race result for the current season, keyed by `meetingKey`.
+ * Rows missing the required fields (non-empty top 10, a Q1 driver and a
+ * fastest lap) are skipped — a result is only shown once it is complete.
+ *
+ * The caller injects the Supabase client (and, optionally, a pre-built
+ * `PredictionContext`). Returns `{}` when there is no current season.
+ */
+export async function fetchRaceResults(
+  supabase: SupabaseClient,
+  context?: PredictionContext | null
+): Promise<Record<number, RaceResult>> {
+  const ctx = context ?? (await createPredictionContext(supabase));
+  if (!ctx) return {};
+  const { raceIdToMeetingKey, findDriver } = ctx;
+
+  const { data: raceResultRows } = await supabase
+    .from("race_results")
+    .select(
+      "race_id, pole_position_driver_id, qualifying_top_3, qualifying_p4_driver_id, top_10, p11_driver_id, fastest_lap_driver_id, fastest_pit_stop_driver_id, driver_of_the_day_driver_id"
+    );
+
+  const raceResults: Record<number, RaceResult> = {};
+  for (const row of raceResultRows ?? []) {
+    const meetingKey = raceIdToMeetingKey.get(row.race_id);
+    if (meetingKey === undefined) continue;
+
+    const top10Ids: number[] = row.top_10 ?? [];
+    const top10 = top10Ids.map((id) => findDriver(id)).filter((d): d is Driver => d !== null);
+    const qualifyingTop3 = buildResultQualifyingTop3(
+      row.qualifying_top_3,
+      row.pole_position_driver_id,
+      findDriver
+    );
+    const qualifyingP4 = findDriver(row.qualifying_p4_driver_id ?? null);
+    const p11 = findDriver(row.p11_driver_id ?? null);
+    const fastestLap = findDriver(row.fastest_lap_driver_id);
+    const fastestPit = findDriver(row.fastest_pit_stop_driver_id);
+    const driverOfTheDay = findDriver(row.driver_of_the_day_driver_id);
+    if (top10.length > 0 && qualifyingTop3[0] && fastestLap) {
+      raceResults[meetingKey] = {
+        raceId: meetingKey,
+        qualifyingTop3,
+        raceWinner: top10[0],
+        top10,
+        fastestLap,
+        ...(qualifyingP4 ? { qualifyingP4 } : {}),
+        ...(p11 ? { p11 } : {}),
+        ...(fastestPit ? { fastestPitStop: fastestPit } : {}),
+        ...(driverOfTheDay ? { driverOfTheDay } : {}),
+      };
+    }
+  }
+
+  return raceResults;
+}
+
+/**
+ * Fetches every sprint result for the current season, keyed by `meetingKey`.
+ * Rows missing the required fields (non-empty top 8, a Q1 driver and a
+ * fastest lap) are skipped.
+ *
+ * The caller injects the Supabase client (and, optionally, a pre-built
+ * `PredictionContext`). Returns `{}` when there is no current season.
+ */
+export async function fetchSprintResults(
+  supabase: SupabaseClient,
+  context?: PredictionContext | null
+): Promise<Record<number, SprintResult>> {
+  const ctx = context ?? (await createPredictionContext(supabase));
+  if (!ctx) return {};
+  const { raceIdToMeetingKey, findDriver } = ctx;
+
+  const { data: sprintResultRows } = await supabase
+    .from("sprint_results")
+    .select(
+      "race_id, sprint_pole_driver_id, qualifying_top_3, qualifying_p4_driver_id, top_8, p9_driver_id, fastest_lap_driver_id"
+    );
+
+  const sprintResults: Record<number, SprintResult> = {};
+  for (const row of sprintResultRows ?? []) {
+    const meetingKey = raceIdToMeetingKey.get(row.race_id);
+    if (meetingKey === undefined) continue;
+
+    const top8Ids: number[] = row.top_8 ?? [];
+    const top8 = top8Ids.map((id) => findDriver(id)).filter((d): d is Driver => d !== null);
+    const qualifyingTop3 = buildResultQualifyingTop3(
+      row.qualifying_top_3,
+      row.sprint_pole_driver_id,
+      findDriver
+    );
+    const qualifyingP4 = findDriver(row.qualifying_p4_driver_id ?? null);
+    const p9 = findDriver(row.p9_driver_id ?? null);
+    const fastestLap = findDriver(row.fastest_lap_driver_id);
+    if (top8.length > 0 && qualifyingTop3[0] && fastestLap) {
+      sprintResults[meetingKey] = {
+        raceId: meetingKey,
+        qualifyingTop3,
+        sprintWinner: top8[0],
+        top8,
+        fastestLap,
+        ...(qualifyingP4 ? { qualifyingP4 } : {}),
+        ...(p9 ? { p9 } : {}),
+      };
+    }
+  }
+
+  return sprintResults;
+}

--- a/packages/shared/messages/en.ts
+++ b/packages/shared/messages/en.ts
@@ -369,6 +369,9 @@ const en = {
     retry: "Retry",
     submitError: "Failed to submit prediction. Please try again.",
     resetError: "Failed to reset prediction. Please try again.",
+    // Results comparison (a11y labels for green/amber slot highlights)
+    exactMatch: "Exact match",
+    closeMatch: "Close (±1)",
   },
 
   // ── Achievements page ───────────────────────────────────────────────────

--- a/packages/shared/messages/es.ts
+++ b/packages/shared/messages/es.ts
@@ -362,6 +362,9 @@ const es: Messages = {
     retry: "Reintentar",
     submitError: "No se pudo enviar la predicción. Inténtalo de nuevo.",
     resetError: "No se pudo reiniciar la predicción. Inténtalo de nuevo.",
+    // Comparación de resultados (etiquetas a11y para los resaltados verde/ámbar)
+    exactMatch: "Acierto exacto",
+    closeMatch: "Cerca (±1)",
   },
 
   // ── Achievements page ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Phase 3 (final iteration) of the mobile migration: the **sprint prediction tab**, **champion prediction tab**, and the post-race **results-comparison display**. This completes the Phase 3 core loop. Verified on physical iPhone (Expo Go) and Android emulator against the live database.

## Shared (`@f1/shared`)

Same extraction pattern established in PR #85/#86 — a service function both apps consume:

- `lib/predictions.ts` — new `createPredictionContext(supabase)` (season id + driver/race id mappings built once per request) and `fetchUserSprintPredictions(supabase, userId, races, context?)`; `fetchUserRacePredictions` keeps its signature with the context as an optional arg.
- `lib/champion-predictions.ts` (new) — `fetchChampionPredictionData` assembling the champion prediction, per-team best-driver picks, and raw season award rows.
- `lib/results.ts` (new) — `fetchRaceResults` / `fetchSprintResults` keyed by meeting key + `buildResultQualifyingTop3`.
- `lib/prediction-status.ts` — `computeRaceMatchStatuses` / `computeSprintMatchStatuses` extracted out of the web component.

Web consumes all of the above: `app/race-prediction/page.tsx` shrank ~270 lines and issues fewer duplicate queries via the shared context. Web behavior is unchanged — all pre-existing tests pass.

## Mobile (`apps/mobile`)

- `(app)/race-prediction` now hosts a **Race / Sprint / Champion** segmented control (`PredictionTabs`). Sprint is disabled with "N/A" on non-sprint rounds (deadline = `sprintDateEnd ?? dateEnd`); the Champion tab swaps the round selector for a championship header with the half-points/closed phase pill.
- New components: `ChampionForm` (WDC, WCC, most wins/podiums/DNFs, per-team best-driver buttons, phase banners), `TeamPickerModal` (WCC bottom sheet), `ResultsPanel` (collapsible official race/sprint results), `BonusBadges`.
- **Results comparison**: `DriverSlot` gained match-status borders (green exact / amber close, a11y-labeled) and `+N` points pills; combined weekend points on sprint rounds — mirroring web.
- Champion half-points flow mirrors web: amber confirm modal with a first-submit note vs a changed-fields list.
- Submits go through the Bearer-auth `apiFetch` with the exact web payloads.

## i18n

Reused existing `predictionsPage.*` keys; added only `exactMatch` / `closeMatch` to both `en.ts` and `es.ts`. Locale key counts stay in parity.

## Docs

- `docs/mobile-migration/mobile-migration-plan.md` — Phase 3 marked ✅ code-complete (pending device verification); **Phase 4 broken into 4a (Home dashboard) / 4b (Achievements) / 4c (Profile & account settings)** sub-phases.
- `docs/mobile-migration/decisions.md` — new dated entry for this iteration.

## Test plan

- [x] `npm run typecheck` (web + mobile) — zero errors
- [x] `npm test` — 28 suites, 406 tests (35 new; new shared libs at 100% lines)
- [x] `npm run lint` — zero errors (2 warnings pre-exist on `main`); translation parity en/es
- [x] `npx expo export --platform android` bundles (1540 modules)
- [x] Manual on-device (iOS Expo Go + Android emulator): sprint tab on a real sprint round, champion submit/update incl. the half-points modal, results highlighting on a scored round, and the team picker bottom sheet
