### PR TITLE
feat: mobile home dashboard screen (Phase 4a)

### DIFF
--- a/apps/mobile/src/app/(app)/index.tsx
+++ b/apps/mobile/src/app/(app)/index.tsx
@@ -1,32 +1,73 @@
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "expo-router";
 import { useState } from "react";
-import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
+import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } from "react-native";
+import { fetchAchievementsData } from "@f1/shared/lib/achievements";
+import { fetchChampionshipStandings } from "@f1/shared/lib/championship-standings";
+import { fetchDashboardData } from "@f1/shared/lib/dashboard";
 import { fetchRaces } from "@f1/shared/lib/races";
-import { getNextRace } from "@f1/shared/lib/race-utils";
 
+import { LeaderboardCard } from "@/components/dashboard/LeaderboardCard";
+import { NextRaceCountdown } from "@/components/dashboard/NextRaceCountdown";
+import { NoUpcomingRaces } from "@/components/dashboard/NoUpcomingRaces";
+import { PointSystemCard } from "@/components/dashboard/PointSystemCard";
+import { RaceCalendarCard } from "@/components/dashboard/RaceCalendarCard";
+import { StandingsCard } from "@/components/dashboard/StandingsCard";
+import { UserSummaryCard } from "@/components/dashboard/UserSummaryCard";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/providers/AuthProvider";
 import { useLanguage } from "@/providers/LanguageProvider";
 
 /**
- * Phase 1 smoke screen, now behind auth — proves every scaffold pillar in
- * one place: NativeWind + F1 palette, shared translations via useLanguage,
- * shared pure + service functions, TanStack Query over the Supabase client,
- * and (Phase 2) the signed-in session + sign out.
- * Replaced by the real screens from Phase 3 onward.
+ * Home dashboard (Phase 4a): ports the web dashboard cards — user summary,
+ * next-race countdown, championship standings, leaderboard top 10, point
+ * system and race calendar. The temporary sign-out button at the bottom moves
+ * to the Profile screen in Phase 4c.
  */
 export default function HomeScreen() {
-  const { t, language, setLanguage } = useLanguage();
+  const { t } = useLanguage();
   const { user, signOut } = useAuth();
   const [signingOut, setSigningOut] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
-  const { data: races, isPending, error, refetch } = useQuery({
+  const userId = user?.id;
+
+  const racesQuery = useQuery({
     queryKey: ["races"],
     queryFn: () => fetchRaces(supabase),
   });
+  const races = racesQuery.data;
 
-  const nextRace = races ? getNextRace(races) : null;
+  const dashboardQuery = useQuery({
+    queryKey: ["dashboard", userId],
+    queryFn: () => fetchDashboardData(supabase, userId!, races!),
+    enabled: Boolean(userId && races),
+  });
+
+  const achievementsQuery = useQuery({
+    queryKey: ["achievements", userId],
+    queryFn: () => fetchAchievementsData(supabase, userId!),
+    enabled: Boolean(userId),
+  });
+
+  // Same query key as the Standings tab so both screens share the cache.
+  const standingsQuery = useQuery({
+    queryKey: ["championshipStandings"],
+    queryFn: () => fetchChampionshipStandings(supabase),
+  });
+
+  async function handleRefresh() {
+    setRefreshing(true);
+    try {
+      await Promise.all([
+        racesQuery.refetch(),
+        dashboardQuery.refetch(),
+        achievementsQuery.refetch(),
+        standingsQuery.refetch(),
+      ]);
+    } finally {
+      setRefreshing(false);
+    }
+  }
 
   async function handleSignOut() {
     setSigningOut(true);
@@ -35,82 +76,86 @@ export default function HomeScreen() {
     await signOut().catch(() => setSigningOut(false));
   }
 
+  const loadError =
+    racesQuery.error ?? dashboardQuery.error ?? achievementsQuery.error ?? standingsQuery.error;
+  const isPending =
+    racesQuery.isPending ||
+    (Boolean(userId && races) && dashboardQuery.isPending) ||
+    (Boolean(userId) && achievementsQuery.isPending) ||
+    standingsQuery.isPending;
+
+  if (loadError) {
+    return (
+      <View className="flex-1 items-center justify-center gap-4 bg-f1-black p-6">
+        <Text className="text-center text-sm text-f1-white/70">{t.predictionsPage.loadError}</Text>
+        <Pressable
+          onPress={() => {
+            racesQuery.refetch();
+            dashboardQuery.refetch();
+            achievementsQuery.refetch();
+            standingsQuery.refetch();
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={t.predictionsPage.retry}
+          className="min-h-11 items-center justify-center rounded-lg bg-f1-red px-6 active:bg-f1-red-hover"
+        >
+          <Text className="font-semibold text-white">{t.predictionsPage.retry}</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const dashboard = dashboardQuery.data;
+  const achievements = achievementsQuery.data;
+  const standings = standingsQuery.data;
+
+  if (isPending || !dashboard || !achievements || !standings) {
+    return (
+      <View className="flex-1 items-center justify-center bg-f1-black p-6">
+        <ActivityIndicator color="#CF2637" />
+      </View>
+    );
+  }
+
   return (
-    <ScrollView className="flex-1 bg-f1-black" contentContainerClassName="p-6 gap-6">
-      <View className="gap-1">
-        <Text className="text-3xl font-bold text-f1-white">F1 Prediction</Text>
-        <Text className="text-f1-red font-semibold">{t.navbar.season}</Text>
+    <ScrollView
+      className="flex-1 bg-f1-black"
+      contentContainerClassName="gap-4 p-4"
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor="#CF2637" />
+      }
+    >
+      <UserSummaryCard
+        stats={dashboard.userStats}
+        earnedCount={achievements.earnedIds.length}
+        totalAchievements={achievements.achievements.length}
+      />
+
+      {dashboard.nextRace ? <NextRaceCountdown race={dashboard.nextRace} /> : <NoUpcomingRaces />}
+
+      <StandingsCard standings={standings} />
+
+      <LeaderboardCard entries={dashboard.leaderboard} currentUserId={userId} />
+
+      <View className="flex-row gap-4">
+        <PointSystemCard />
+        <RaceCalendarCard entries={dashboard.calendarEntries} />
       </View>
 
-      <Link href="/race-prediction" asChild>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t.nav.predictions}
-          className="flex-row items-center justify-between rounded-2xl bg-f1-red p-5 active:bg-f1-red-hover"
-        >
-          <View className="gap-0.5">
-            <Text className="text-lg font-bold text-white">{t.nav.predictions}</Text>
-            {nextRace ? (
-              <Text className="text-xs text-white/80">{nextRace.raceName}</Text>
-            ) : null}
-          </View>
-          <Text className="text-2xl text-white">›</Text>
-        </Pressable>
-      </Link>
-
-      <View className="rounded-2xl bg-f1-white/5 border border-f1-white/10 p-4 gap-2">
-        <Text className="text-f1-purple font-semibold">{t.navbar.signedInAs}</Text>
-        <Text className="text-f1-white">{user?.email}</Text>
-        <Pressable
-          onPress={handleSignOut}
-          disabled={signingOut}
-          accessibilityRole="button"
-          className={`mt-2 self-start rounded-lg border border-f1-white/10 bg-f1-white/5 px-4 py-2 active:bg-f1-white/10 ${
-            signingOut ? "opacity-50" : ""
-          }`}
-        >
-          <Text className="font-semibold text-f1-white">
-            {signingOut ? t.navbar.signingOut : t.navbar.signOut}
-          </Text>
-        </Pressable>
-      </View>
-
-      <View className="rounded-2xl bg-f1-white/5 border border-f1-white/10 p-4 gap-2">
-        <Text className="text-f1-amber font-semibold">Supabase + TanStack Query</Text>
-        {isPending ? (
-          <ActivityIndicator color="#CF2637" />
-        ) : error ? (
-          <Text className="text-f1-red">{String(error)}</Text>
-        ) : (
-          <>
-            <Text className="text-f1-white">
-              {races?.length ?? 0} races loaded from the live database
-            </Text>
-            {nextRace ? (
-              <Text className="text-f1-blue">Next: {nextRace.raceName}</Text>
-            ) : null}
-          </>
-        )}
-        <Pressable
-          onPress={() => refetch()}
-          className="mt-2 self-start rounded-lg bg-f1-red px-4 py-2 active:bg-f1-red-hover"
-        >
-          <Text className="font-semibold text-white">Refetch</Text>
-        </Pressable>
-      </View>
-
-      <View className="rounded-2xl bg-f1-white/5 border border-f1-white/10 p-4 gap-2">
-        <Text className="text-f1-green font-semibold">i18n ({language})</Text>
-        <Text className="text-f1-white">{t.nav.leaderboard}</Text>
-        <Pressable
-          onPress={() => setLanguage(language === "en" ? "es" : "en")}
-          className="mt-2 self-start rounded-lg bg-f1-purple px-4 py-2"
-        >
-          <Text className="font-semibold text-white">
-            {language === "en" ? "Español" : "English"}
-          </Text>
-        </Pressable>
-      </View>
+      {/* Temporary sign-out until the Profile screen ships (Phase 4c). */}
+      <Pressable
+        onPress={handleSignOut}
+        disabled={signingOut}
+        accessibilityRole="button"
+        accessibilityLabel={t.navbar.signOut}
+        className={`min-h-11 items-center justify-center rounded-lg border border-f1-white/10 bg-f1-white/5 active:bg-f1-white/10 ${
+          signingOut ? "opacity-50" : ""
+        }`}
+      >
+        <Text className="text-sm font-semibold text-f1-white/70">
+          {signingOut ? t.navbar.signingOut : t.navbar.signOut}
+        </Text>
+      </Pressable>
     </ScrollView>
   );
 }

--- a/apps/mobile/src/components/dashboard/LeaderboardCard.tsx
+++ b/apps/mobile/src/components/dashboard/LeaderboardCard.tsx
@@ -1,0 +1,86 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { Pressable, Text, View } from "react-native";
+import type { LeaderboardEntry } from "@f1/shared/types";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+import { RankBadge } from "./RankBadge";
+
+interface LeaderboardCardProps {
+  entries: LeaderboardEntry[];
+  currentUserId?: string;
+}
+
+/**
+ * Ports the web LeaderboardCard: compact top-10 summary with a "you"
+ * highlight. Pressing the card navigates to the Leaderboard tab.
+ */
+export function LeaderboardCard({ entries, currentUserId }: LeaderboardCardProps) {
+  const { t } = useLanguage();
+  const router = useRouter();
+
+  return (
+    <Pressable
+      onPress={() => router.navigate("/leaderboard")}
+      accessibilityRole="button"
+      accessibilityLabel={`${t.leaderboardCard.leaderboard} — ${t.leaderboardCard.viewAll}`}
+      className="rounded-2xl border border-f1-white/10 bg-f1-white/5 p-5 active:bg-f1-white/10"
+    >
+      <View className="flex-row items-center justify-between">
+        <View className="flex-1 flex-row items-center gap-2">
+          <Ionicons name="medal" size={16} color="#FFB100" />
+          <Text className="text-xs font-medium uppercase tracking-wider text-f1-white/50">
+            {t.leaderboardCard.leaderboard}
+          </Text>
+          <View className="rounded bg-f1-amber/15 px-1.5 py-0.5">
+            <Text className="text-[9px] font-bold uppercase tracking-wider text-f1-amber">
+              Top 10
+            </Text>
+          </View>
+        </View>
+        <View className="flex-row items-center gap-0.5">
+          <Text className="text-[10px] font-medium text-f1-white/50">
+            {t.leaderboardCard.viewAll}
+          </Text>
+          <Ionicons name="chevron-forward" size={12} color="#F7F7F780" />
+        </View>
+      </View>
+
+      <View className="mt-3 gap-0.5">
+        {entries.map((entry) => {
+          const isMe = entry.userId === currentUserId;
+          return (
+            <View
+              key={entry.userId}
+              className={`flex-row items-center justify-between rounded-md px-2 py-1.5 ${
+                isMe ? "bg-f1-red/10" : ""
+              }`}
+            >
+              <View className="flex-1 flex-row items-center gap-2">
+                <RankBadge rank={entry.rank} />
+                <Text
+                  className={`flex-1 text-xs font-medium ${
+                    isMe ? "text-f1-white" : "text-f1-white/50"
+                  }`}
+                  numberOfLines={1}
+                >
+                  {entry.displayName}
+                  {isMe ? (
+                    <Text className="text-[10px] text-f1-red"> ({t.leaderboardCard.you})</Text>
+                  ) : null}
+                </Text>
+              </View>
+              <Text className="ml-2 text-xs font-semibold tabular-nums text-f1-white">
+                {entry.totalPoints}
+                <Text className="text-[10px] font-normal text-f1-white/50">
+                  {" "}
+                  {t.leaderboardCard.pts}
+                </Text>
+              </Text>
+            </View>
+          );
+        })}
+      </View>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/dashboard/NextRaceCountdown.tsx
+++ b/apps/mobile/src/components/dashboard/NextRaceCountdown.tsx
@@ -1,0 +1,158 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import { countryCodeToFlag, getRaceStatus } from "@f1/shared/lib/race-utils";
+import type { Race } from "@f1/shared/types";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+interface TimeLeft {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+}
+
+function calculateTimeLeft(targetDate: string): TimeLeft {
+  const diff = new Date(targetDate).getTime() - Date.now();
+  if (diff <= 0) return { days: 0, hours: 0, minutes: 0, seconds: 0 };
+  return {
+    days: Math.floor(diff / (1000 * 60 * 60 * 24)),
+    hours: Math.floor((diff / (1000 * 60 * 60)) % 24),
+    minutes: Math.floor((diff / (1000 * 60)) % 60),
+    seconds: Math.floor((diff / 1000) % 60),
+  };
+}
+
+/** Active prediction deadline: the sprint deadline while it's still open, else the race deadline. */
+function getActiveDeadline(race: Race): string {
+  const now = Date.now();
+  const sprintDeadline = race.sprintDateEnd ? new Date(race.sprintDateEnd).getTime() : null;
+  return sprintDeadline && sprintDeadline > now ? race.sprintDateEnd! : race.dateEnd;
+}
+
+function TimeUnit({ value, label }: { value: number; label: string }) {
+  return (
+    <View className="items-center">
+      <Text className="text-2xl font-bold tabular-nums text-f1-white">
+        {String(value).padStart(2, "0")}
+      </Text>
+      <Text className="text-[10px] uppercase text-f1-white/50">{label}</Text>
+    </View>
+  );
+}
+
+/**
+ * Ports the web NextRaceCountdown: next-race info, live/upcoming status badge,
+ * ticking d:h:m:s countdown to the active prediction deadline, and a CTA that
+ * jumps to the Predictions tab (which already defaults to the next open round).
+ */
+export function NextRaceCountdown({ race }: { race: Race }) {
+  const { t } = useLanguage();
+  const router = useRouter();
+
+  const [timeLeft, setTimeLeft] = useState<TimeLeft>(() =>
+    calculateTimeLeft(getActiveDeadline(race))
+  );
+  const [status, setStatus] = useState(() => getRaceStatus(race));
+  const [deadlinePassed, setDeadlinePassed] = useState(
+    () => new Date(getActiveDeadline(race)).getTime() <= Date.now()
+  );
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const deadline = getActiveDeadline(race);
+      setTimeLeft(calculateTimeLeft(deadline));
+      setStatus(getRaceStatus(race));
+      setDeadlinePassed(new Date(deadline).getTime() <= Date.now());
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [race]);
+
+  const isWeekendLive = status === "live";
+  const showLiveBadge = deadlinePassed || isWeekendLive;
+
+  return (
+    <View className="rounded-2xl border border-f1-white/10 bg-f1-white/5 p-5">
+      {/* Header: label + status badge */}
+      <View className="flex-row items-start justify-between">
+        <Text className="text-xs font-medium uppercase tracking-wider text-f1-white/50">
+          {showLiveBadge ? t.nextRace.raceWeekend : t.nextRace.nextRace}
+        </Text>
+        {showLiveBadge ? (
+          <View className="flex-row items-center gap-1.5 rounded-full bg-f1-red/15 px-2.5 py-1">
+            <Ionicons name="radio" size={10} color="#CF2637" />
+            <Text className="text-[10px] font-semibold uppercase text-f1-red">
+              {t.nextRace.live}
+            </Text>
+          </View>
+        ) : (
+          <View className="flex-row items-center gap-1.5 rounded-full bg-f1-green/15 px-2.5 py-1">
+            <Ionicons name="time-outline" size={10} color="#44AF69" />
+            <Text className="text-[10px] font-semibold uppercase text-f1-green">
+              {t.nextRace.upcoming}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      {/* Race name + location */}
+      <View className="mt-3">
+        <View className="flex-row items-center gap-2">
+          <Text className="text-base">{countryCodeToFlag(race.countryCode)}</Text>
+          <Text className="flex-1 text-sm font-semibold text-f1-white" numberOfLines={1}>
+            {race.raceName}
+          </Text>
+        </View>
+        <View className="mt-1 flex-row items-center gap-1">
+          <Ionicons name="location-outline" size={12} color="#F7F7F780" />
+          <Text className="text-xs text-f1-white/50" numberOfLines={1}>
+            {race.location}, {race.countryName}
+          </Text>
+        </View>
+      </View>
+
+      {/* Countdown / lights-out */}
+      {!deadlinePassed ? (
+        <View
+          className="mt-4"
+          accessibilityRole="text"
+          accessibilityLabel={`${t.nextRace.predictionDeadline}: ${timeLeft.days}d ${timeLeft.hours}h ${timeLeft.minutes}m`}
+        >
+          <View className="flex-row items-start justify-center gap-3">
+            <TimeUnit value={timeLeft.days} label={t.nextRace.days} />
+            <Text className="pt-1 text-lg text-f1-white/50">:</Text>
+            <TimeUnit value={timeLeft.hours} label={t.nextRace.hrs} />
+            <Text className="pt-1 text-lg text-f1-white/50">:</Text>
+            <TimeUnit value={timeLeft.minutes} label={t.nextRace.min} />
+            <Text className="pt-1 text-lg text-f1-white/50">:</Text>
+            <TimeUnit value={timeLeft.seconds} label={t.nextRace.sec} />
+          </View>
+          <Text className="mt-2 text-center text-[10px] text-f1-white/50">
+            {t.nextRace.predictionDeadline}
+          </Text>
+        </View>
+      ) : (
+        <View className="mt-4 rounded-lg bg-f1-red/5 px-3 py-3">
+          <Text className="text-center text-sm font-medium text-f1-white">
+            {t.nextRace.lightsOut}
+          </Text>
+        </View>
+      )}
+
+      {/* CTA while the deadline is open */}
+      {!deadlinePassed ? (
+        <Pressable
+          onPress={() => router.navigate("/race-prediction")}
+          accessibilityRole="button"
+          accessibilityLabel={t.nextRace.makePrediction}
+          className="mt-4 min-h-11 flex-row items-center justify-center gap-1 rounded-lg bg-f1-red active:bg-f1-red-hover"
+        >
+          <Text className="text-xs font-semibold text-white">{t.nextRace.makePrediction}</Text>
+          <Ionicons name="chevron-forward" size={14} color="#FFFFFF" />
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/dashboard/NoUpcomingRaces.tsx
+++ b/apps/mobile/src/components/dashboard/NoUpcomingRaces.tsx
@@ -1,0 +1,13 @@
+import { Text, View } from "react-native";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+/** Ports the web NoUpcomingRaces: shown in place of the countdown after the season ends. */
+export function NoUpcomingRaces() {
+  const { t } = useLanguage();
+  return (
+    <View className="items-center justify-center rounded-2xl border border-f1-white/10 bg-f1-white/5 p-6">
+      <Text className="text-sm text-f1-white/50">{t.nextRace.noUpcoming}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/dashboard/PointSystemCard.tsx
+++ b/apps/mobile/src/components/dashboard/PointSystemCard.tsx
@@ -1,0 +1,43 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import { buildPointSystem } from "@f1/shared/lib/point-system";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+import { PointSystemModal } from "./PointSystemModal";
+
+/** Ports the web PointSystemCard: tap to open the scoring rules bottom sheet. */
+export function PointSystemCard() {
+  const { t } = useLanguage();
+  const [modalOpen, setModalOpen] = useState(false);
+  const sections = buildPointSystem(t.pointSystem.sections);
+
+  return (
+    <>
+      <Pressable
+        onPress={() => setModalOpen(true)}
+        accessibilityRole="button"
+        accessibilityLabel={`${t.pointSystem.title} — ${t.pointSystem.tapToView}`}
+        className="flex-1 items-center justify-center gap-3 rounded-2xl border border-f1-white/10 bg-f1-white/5 p-5 active:bg-f1-white/10"
+      >
+        <View className="h-10 w-10 items-center justify-center rounded-xl bg-f1-purple/10">
+          <Ionicons name="help-circle-outline" size={20} color="#A06CD5" />
+        </View>
+        <View>
+          <Text className="text-center text-xs font-medium text-f1-white">
+            {t.pointSystem.title}
+          </Text>
+          <Text className="mt-0.5 text-center text-[10px] text-f1-white/50">
+            {t.pointSystem.tapToView}
+          </Text>
+        </View>
+      </Pressable>
+
+      <PointSystemModal
+        visible={modalOpen}
+        sections={sections}
+        onClose={() => setModalOpen(false)}
+      />
+    </>
+  );
+}

--- a/apps/mobile/src/components/dashboard/PointSystemModal.tsx
+++ b/apps/mobile/src/components/dashboard/PointSystemModal.tsx
@@ -1,0 +1,140 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useState } from "react";
+import { Modal, Pressable, ScrollView, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import type { PointSystemRule, PointSystemSection } from "@f1/shared/types";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+interface PointSystemModalProps {
+  visible: boolean;
+  sections: PointSystemSection[];
+  onClose: () => void;
+}
+
+/**
+ * Ports the web PointSystemModal as a bottom sheet (TeamPickerModal pattern).
+ * The web hover tooltips for worked examples become tap-to-expand rows.
+ */
+export function PointSystemModal({ visible, sections, onClose }: PointSystemModalProps) {
+  const { t } = useLanguage();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View className="flex-1 justify-end bg-black/60">
+        <Pressable
+          className="flex-1"
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel={t.predictionsPage.dismiss}
+        />
+        <View
+          className="max-h-[85%] rounded-t-3xl border-t border-f1-purple/30 bg-f1-black"
+          style={{ paddingBottom: insets.bottom }}
+        >
+          {/* Header */}
+          <View className="flex-row items-start justify-between border-b border-f1-white/10 px-5 py-4">
+            <View className="flex-1 flex-row items-center gap-2.5">
+              <View className="h-9 w-9 items-center justify-center rounded-xl bg-f1-purple/15">
+                <Ionicons name="sparkles" size={18} color="#A06CD5" />
+              </View>
+              <View className="flex-1">
+                <Text className="text-base font-bold text-f1-white" numberOfLines={1}>
+                  {t.pointSystem.modalTitle}
+                </Text>
+                <Text className="mt-0.5 text-[11px] text-f1-white/50" numberOfLines={2}>
+                  {t.pointSystem.modalSubtitle}
+                </Text>
+              </View>
+            </View>
+            <Pressable
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel={t.pointSystem.closeModal}
+              className="h-8 w-8 items-center justify-center rounded-full bg-f1-white/10 active:bg-f1-white/20"
+            >
+              <Ionicons name="close" size={16} color="#F7F7F7" />
+            </Pressable>
+          </View>
+
+          <ScrollView contentContainerClassName="gap-6 p-5">
+            {sections.map((section) => (
+              <View key={section.title}>
+                <View className="flex-row items-center justify-between">
+                  <Text className="flex-1 text-sm font-semibold text-f1-white" numberOfLines={1}>
+                    {section.title}
+                  </Text>
+                  <View className="rounded-full bg-f1-red/10 px-2.5 py-0.5">
+                    <Text className="text-[10px] font-semibold text-f1-red">
+                      {t.pointSystem.max} {section.maxPoints} {t.pointSystem.pts}
+                    </Text>
+                  </View>
+                </View>
+                <View className="mt-3 gap-1">
+                  {section.rules.map((rule) => (
+                    <RuleRow key={rule.category} rule={rule} />
+                  ))}
+                </View>
+              </View>
+            ))}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+/** One scoring rule; rules with a worked example expand it inline on tap. */
+function RuleRow({ rule }: { rule: PointSystemRule }) {
+  const { t } = useLanguage();
+  const [expanded, setExpanded] = useState(false);
+  const hasExample = Boolean(rule.example);
+
+  const body = (
+    <>
+      <View className="flex-row items-center justify-between">
+        <View className="flex-1 flex-row items-center gap-1.5">
+          <Text className="text-xs font-medium text-f1-white" numberOfLines={1}>
+            {rule.category}
+          </Text>
+          {hasExample ? (
+            <Ionicons
+              name="information-circle-outline"
+              size={13}
+              color={expanded ? "#A06CD5" : "#A06CD5B3"}
+            />
+          ) : null}
+        </View>
+        <Text className="ml-4 text-xs font-semibold tabular-nums text-f1-amber">
+          +{rule.points}
+        </Text>
+      </View>
+      <Text className="mt-0.5 text-[10px] text-f1-white/50">{rule.description}</Text>
+      {expanded && hasExample ? (
+        <View className="mt-2 rounded-lg border border-f1-purple/30 bg-f1-purple/5 p-2.5">
+          <Text className="text-[9px] font-semibold uppercase tracking-wide text-f1-purple">
+            {t.pointSystem.example}
+          </Text>
+          <Text className="mt-0.5 text-[11px] leading-relaxed text-f1-white">{rule.example}</Text>
+        </View>
+      ) : null}
+    </>
+  );
+
+  if (!hasExample) {
+    return <View className="rounded-md px-3 py-2">{body}</View>;
+  }
+
+  return (
+    <Pressable
+      onPress={() => setExpanded((v) => !v)}
+      accessibilityRole="button"
+      accessibilityLabel={`${rule.category} — ${t.pointSystem.showExample}`}
+      accessibilityState={{ expanded }}
+      className="rounded-md bg-f1-purple/5 px-3 py-2 active:bg-f1-purple/10"
+    >
+      {body}
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/dashboard/RaceCalendarCard.tsx
+++ b/apps/mobile/src/components/dashboard/RaceCalendarCard.tsx
@@ -1,0 +1,42 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import type { RaceCalendarEntry } from "@f1/shared/lib/race-utils";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+import { RaceCalendarModal } from "./RaceCalendarModal";
+
+/** Ports the web RaceCalendarCard: tap to open the season calendar bottom sheet. */
+export function RaceCalendarCard({ entries }: { entries: RaceCalendarEntry[] }) {
+  const { t } = useLanguage();
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <>
+      <Pressable
+        onPress={() => setModalOpen(true)}
+        accessibilityRole="button"
+        accessibilityLabel={`${t.raceCalendar.title} — ${t.raceCalendar.tapToView}`}
+        className="flex-1 items-center justify-center gap-3 rounded-2xl border border-f1-white/10 bg-f1-white/5 p-5 active:bg-f1-white/10"
+      >
+        <View className="h-10 w-10 items-center justify-center rounded-xl bg-f1-red/10">
+          <Ionicons name="calendar-outline" size={20} color="#CF2637" />
+        </View>
+        <View>
+          <Text className="text-center text-xs font-medium text-f1-white">
+            {t.raceCalendar.title}
+          </Text>
+          <Text className="mt-0.5 text-center text-[10px] text-f1-white/50">
+            {t.raceCalendar.tapToView}
+          </Text>
+        </View>
+      </Pressable>
+
+      <RaceCalendarModal
+        visible={modalOpen}
+        entries={entries}
+        onClose={() => setModalOpen(false)}
+      />
+    </>
+  );
+}

--- a/apps/mobile/src/components/dashboard/RaceCalendarModal.tsx
+++ b/apps/mobile/src/components/dashboard/RaceCalendarModal.tsx
@@ -1,0 +1,179 @@
+import { Ionicons } from "@expo/vector-icons";
+import { FlatList, Modal, Pressable, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { countryCodeToFlag, type RaceCalendarEntry } from "@f1/shared/lib/race-utils";
+import type { PredictionStatus } from "@f1/shared/types";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+interface RaceCalendarModalProps {
+  visible: boolean;
+  entries: RaceCalendarEntry[];
+  onClose: () => void;
+}
+
+/** Fixed row height so initialScrollIndex can jump straight to the next race. */
+const ROW_HEIGHT = 60;
+
+/**
+ * Ports the web RaceCalendarModal as a bottom sheet: the full season list with
+ * per-race prediction status, opened scrolled to the next (live/upcoming) race.
+ */
+export function RaceCalendarModal({ visible, entries, onClose }: RaceCalendarModalProps) {
+  const { t } = useLanguage();
+  const insets = useSafeAreaInsets();
+
+  // First non-completed race: highlighted and used as the initial scroll target.
+  const nextEntryIndex = entries.findIndex(
+    (e) => e.raceStatus === "live" || e.raceStatus === "upcoming"
+  );
+
+  const seasonYear =
+    entries.length > 0
+      ? new Date(entries[0].race.dateStart).getFullYear()
+      : new Date().getFullYear();
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View className="flex-1 justify-end bg-black/60">
+        <Pressable
+          className="flex-1"
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel={t.predictionsPage.dismiss}
+        />
+        <View
+          className="h-[85%] rounded-t-3xl border-t border-f1-white/10 bg-f1-black"
+          style={{ paddingBottom: insets.bottom }}
+        >
+          {/* Header */}
+          <View className="flex-row items-center justify-between border-b border-f1-white/10 px-5 py-4">
+            <Text className="flex-1 text-sm font-bold uppercase tracking-wider text-f1-white">
+              {t.raceCalendar.modalTitle.replace("{{year}}", String(seasonYear))}
+            </Text>
+            <Pressable
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel={t.raceCalendar.closeModal}
+              className="h-8 w-8 items-center justify-center rounded-full bg-f1-white/10 active:bg-f1-white/20"
+            >
+              <Ionicons name="close" size={16} color="#F7F7F7" />
+            </Pressable>
+          </View>
+
+          <FlatList
+            data={entries}
+            keyExtractor={(entry) => String(entry.race.meetingKey)}
+            contentContainerClassName="gap-1 p-4"
+            initialScrollIndex={nextEntryIndex > 0 ? nextEntryIndex : undefined}
+            getItemLayout={(_, index) => ({
+              // gap-1 adds 4px between the fixed-height rows
+              length: ROW_HEIGHT + 4,
+              offset: (ROW_HEIGHT + 4) * index,
+              index,
+            })}
+            renderItem={({ item: entry, index }) => (
+              <CalendarRow entry={entry} isNext={index === nextEntryIndex} />
+            )}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function CalendarRow({ entry, isNext }: { entry: RaceCalendarEntry; isNext: boolean }) {
+  const { t } = useLanguage();
+  const { race, raceStatus, predictionStatus } = entry;
+  const isCompleted = raceStatus === "completed";
+  const isLive = raceStatus === "live";
+
+  return (
+    <View
+      style={{ height: ROW_HEIGHT }}
+      className={`flex-row items-center gap-3 rounded-xl px-3 ${
+        isNext ? "border border-f1-red/30 bg-f1-red/5" : isCompleted ? "opacity-50" : ""
+      }`}
+    >
+      {/* Round number */}
+      <View
+        className={`h-7 w-7 items-center justify-center rounded-full ${
+          isLive ? "bg-f1-red" : isNext ? "bg-f1-red/20" : "bg-f1-white/10"
+        }`}
+      >
+        <Text
+          className={`text-[10px] font-bold ${
+            isLive ? "text-white" : isNext ? "text-f1-red" : "text-f1-white/50"
+          }`}
+        >
+          {race.round}
+        </Text>
+      </View>
+
+      {/* Race info */}
+      <View className="flex-1">
+        <View className="flex-row items-center gap-1.5">
+          <Text className="text-xs">{countryCodeToFlag(race.countryCode)}</Text>
+          <Text className="flex-1 text-xs font-medium text-f1-white" numberOfLines={1}>
+            {race.raceName}
+          </Text>
+        </View>
+        <Text className="mt-0.5 text-[10px] text-f1-white/50" numberOfLines={1}>
+          {race.circuitShortName} · {formatLocalDate(race.dateStart, race.dateEnd)}
+        </Text>
+      </View>
+
+      {/* Badges */}
+      <View className="flex-row items-center gap-1.5">
+        {race.hasSprint ? (
+          <View className="flex-row items-center gap-0.5 rounded-full bg-f1-purple/10 px-1.5 py-0.5">
+            <Ionicons name="flash" size={10} color="#A06CD5" />
+            <Text className="text-[9px] font-semibold text-f1-purple">
+              {t.raceCalendar.sprint}
+            </Text>
+          </View>
+        ) : null}
+
+        {isLive ? (
+          <View className="flex-row items-center gap-1 rounded-full bg-f1-red/10 px-2 py-0.5">
+            <View className="h-1.5 w-1.5 rounded-full bg-f1-red" />
+            <Text className="text-[9px] font-semibold text-f1-red">{t.raceCalendar.live}</Text>
+          </View>
+        ) : predictionStatus ? (
+          <PredictionBadge status={predictionStatus} />
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function PredictionBadge({ status }: { status: PredictionStatus }) {
+  const { t } = useLanguage();
+  const config = {
+    pending: { label: t.predictionsCard.pending, cls: "bg-f1-amber/10", text: "text-f1-amber" },
+    submitted: { label: t.predictionsCard.submitted, cls: "bg-f1-blue/10", text: "text-f1-blue" },
+    scored: { label: t.predictionsCard.scored, cls: "bg-f1-green/10", text: "text-f1-green" },
+  } as const;
+  const { label, cls, text } = config[status];
+  return (
+    <View className={`rounded-full px-2 py-0.5 ${cls}`}>
+      <Text className={`text-[9px] font-semibold ${text}`}>{label}</Text>
+    </View>
+  );
+}
+
+/** "14–16 Mar" style local date range, same as the web modal. */
+function formatLocalDate(dateStart: string, dateEnd: string): string {
+  const start = new Date(dateStart);
+  const end = new Date(dateEnd);
+
+  const dayFmt = new Intl.DateTimeFormat(undefined, { day: "numeric" });
+  const monthFmt = new Intl.DateTimeFormat(undefined, { month: "short" });
+
+  const startDay = dayFmt.format(start);
+  const endDay = dayFmt.format(end);
+  const month = monthFmt.format(end);
+
+  if (startDay === endDay) return `${startDay} ${month}`;
+  return `${startDay}–${endDay} ${month}`;
+}

--- a/apps/mobile/src/components/dashboard/RankBadge.tsx
+++ b/apps/mobile/src/components/dashboard/RankBadge.tsx
@@ -1,0 +1,34 @@
+import { Text, View } from "react-native";
+
+/**
+ * Amber / silver / bronze badge for the top 3, plain number below — the same
+ * treatment the web dashboard cards and the mobile Leaderboard screen use.
+ */
+export function RankBadge({ rank }: { rank: number }) {
+  if (rank === 1) {
+    return (
+      <View className="h-6 w-6 items-center justify-center rounded-full bg-f1-amber/15">
+        <Text className="text-[10px] font-bold text-f1-amber">1</Text>
+      </View>
+    );
+  }
+  if (rank === 2) {
+    return (
+      <View className="h-6 w-6 items-center justify-center rounded-full bg-gray-400/15">
+        <Text className="text-[10px] font-bold text-gray-400">2</Text>
+      </View>
+    );
+  }
+  if (rank === 3) {
+    return (
+      <View className="h-6 w-6 items-center justify-center rounded-full bg-amber-700/15">
+        <Text className="text-[10px] font-bold text-amber-700">3</Text>
+      </View>
+    );
+  }
+  return (
+    <View className="h-6 w-6 items-center justify-center">
+      <Text className="text-[10px] tabular-nums text-f1-white/50">{rank}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/dashboard/StandingsCard.tsx
+++ b/apps/mobile/src/components/dashboard/StandingsCard.tsx
@@ -1,0 +1,84 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { Pressable, Text, View } from "react-native";
+import type { ChampionshipStandings } from "@f1/shared/types";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+import { RankBadge } from "./RankBadge";
+
+/**
+ * Ports the web StandingsCard: compact WDC top-5 summary. Pressing the card
+ * navigates to the Standings tab (the web opens a modal; mobile already has a
+ * full Standings screen, so we reuse it and share its query cache).
+ */
+export function StandingsCard({ standings }: { standings: ChampionshipStandings }) {
+  const { t } = useLanguage();
+  const router = useRouter();
+
+  const topFive = standings.wdc.slice(0, 5);
+  const hasData = topFive.length > 0;
+
+  return (
+    <Pressable
+      onPress={() => router.navigate("/standings")}
+      accessibilityRole="button"
+      accessibilityLabel={`${t.standingsCard.title} — ${t.standingsCard.viewAll}`}
+      className="rounded-2xl border border-f1-white/10 bg-f1-white/5 p-5 active:bg-f1-white/10"
+    >
+      <View className="flex-row items-center justify-between">
+        <View className="flex-row items-center gap-2">
+          <Ionicons name="trophy" size={16} color="#FFB100" />
+          <Text className="text-xs font-medium uppercase tracking-wider text-f1-white/50">
+            {t.standingsCard.title}
+          </Text>
+        </View>
+        <View className="flex-row items-center gap-0.5">
+          <Text className="text-[10px] font-medium text-f1-white/50">
+            {t.standingsCard.viewAll}
+          </Text>
+          <Ionicons name="chevron-forward" size={12} color="#F7F7F780" />
+        </View>
+      </View>
+
+      {hasData ? (
+        <View className="mt-3 gap-0.5">
+          {topFive.map((entry) => (
+            <View
+              key={entry.driverId}
+              className="flex-row items-center justify-between rounded-md px-2 py-1.5"
+            >
+              <View className="flex-1 flex-row items-center gap-2">
+                <RankBadge rank={entry.rank} />
+                <View
+                  className="h-6 w-1 rounded-sm"
+                  style={{ backgroundColor: `#${entry.driver.teamColor}` }}
+                />
+                <View className="flex-1">
+                  <Text className="text-xs font-medium text-f1-white" numberOfLines={1}>
+                    {entry.driver.firstName.charAt(0)}. {entry.driver.lastName}
+                  </Text>
+                  <Text className="text-[10px] text-f1-white/50" numberOfLines={1}>
+                    {entry.driver.teamName}
+                  </Text>
+                </View>
+              </View>
+              <Text className="ml-2 text-xs font-semibold tabular-nums text-f1-white">
+                {entry.points}
+                <Text className="text-[10px] font-normal text-f1-white/50">
+                  {" "}
+                  {t.standingsCard.pts}
+                </Text>
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : (
+        <View className="mt-3 items-center justify-center rounded-lg border border-dashed border-f1-white/10 p-4">
+          <Text className="text-center text-[11px] text-f1-white/50">
+            {t.standingsCard.noData}
+          </Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/dashboard/UserSummaryCard.tsx
+++ b/apps/mobile/src/components/dashboard/UserSummaryCard.tsx
@@ -1,0 +1,80 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
+import type { UserStats } from "@f1/shared/types";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+interface UserSummaryCardProps {
+  stats: UserStats;
+  /** Number of achievements the user has earned. */
+  earnedCount: number;
+  /** Total number of achievements available. */
+  totalAchievements: number;
+}
+
+/**
+ * Ports the web UserSummaryCard: total points + rank on the left,
+ * achievements-earned progress on the right. The web per-slug lucide icon
+ * previews are replaced by an amber progress bar (the icon map is web-only;
+ * the full achievements screen ships in Phase 4c).
+ */
+export function UserSummaryCard({ stats, earnedCount, totalAchievements }: UserSummaryCardProps) {
+  const { t } = useLanguage();
+  const progress = totalAchievements > 0 ? Math.min(earnedCount / totalAchievements, 1) : 0;
+
+  return (
+    <View className="flex-row gap-4 rounded-2xl border border-f1-white/10 bg-f1-white/5 p-5">
+      {/* Left: points + rank */}
+      <View className="flex-1 justify-between gap-4">
+        <View>
+          <Text className="text-xs font-medium uppercase tracking-wider text-f1-white/50">
+            {t.userPoints.yourPoints}
+          </Text>
+          <Text className="mt-1 text-4xl font-bold tabular-nums text-f1-white">
+            {stats.totalPoints}
+          </Text>
+        </View>
+        <View className="flex-row items-center gap-2">
+          <Ionicons name="trending-up" size={14} color="#44AF69" />
+          <View>
+            <Text className="text-lg font-semibold tabular-nums text-f1-white">
+              {stats.rank}
+              <Text className="text-xs text-f1-white/50">/{stats.totalUsers}</Text>
+            </Text>
+            <Text className="text-[10px] text-f1-white/50">{t.userPoints.rank}</Text>
+          </View>
+        </View>
+      </View>
+
+      {/* Right: achievements progress */}
+      <View className="flex-1 justify-between gap-4">
+        <View className="items-end">
+          <Text className="text-right text-xs font-medium uppercase tracking-wider text-f1-white/50">
+            {t.achievementsCard.achievements}
+          </Text>
+          <Text className="mt-1 text-2xl font-bold tabular-nums text-f1-white">
+            {earnedCount}
+            <Text className="text-sm font-normal text-f1-white/50">/{totalAchievements}</Text>
+          </Text>
+        </View>
+
+        {earnedCount > 0 ? (
+          <View
+            accessibilityRole="progressbar"
+            accessibilityLabel={`${t.achievementsCard.achievements}: ${earnedCount}/${totalAchievements}`}
+            className="h-1.5 overflow-hidden rounded-full bg-f1-white/10"
+          >
+            <View
+              className="h-full rounded-full bg-f1-amber"
+              style={{ width: `${Math.round(progress * 100)}%` }}
+            />
+          </View>
+        ) : (
+          <Text className="text-right text-[10px] text-f1-white/50">
+            {t.achievementsCard.noAchievements}
+          </Text>
+        )}
+      </View>
+    </View>
+  );
+}

--- a/apps/web/__tests__/lib/dashboard.test.ts
+++ b/apps/web/__tests__/lib/dashboard.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Tests for packages/shared/lib/dashboard.ts — buildDashboardPredictions
+ * (pure) directly, fetchDashboardData with mocked Supabase.
+ *
+ * Query order inside fetchDashboardData (matters for the mock queues):
+ *   Promise.all builds the chains in order — the two `.single()` calls consume
+ *   synchronously while the array literal is evaluated, the list thenables
+ *   consume when Promise.all awaits them:
+ *     1. profiles (.single(), user profile)   — first "profiles" queue entry
+ *     2. seasons  (.single(), is_current)
+ *     3. race_predictions (user rows)
+ *     4. sprint_predictions (user rows)
+ *     5. profiles (ordered list, all users)   — second "profiles" queue entry
+ *     6. leaderboard (totals rows)
+ *   Then: races (id, meeting_key map, scoped to the current season).
+ */
+import { createMockSupabase } from "../helpers/mockSupabase";
+import {
+  buildDashboardPredictions,
+  fetchDashboardData,
+  type UserPredictionRow,
+} from "@f1/shared/lib/dashboard";
+import type { Race } from "@f1/shared/types";
+
+const USER_ID = "user-123";
+const SEASON_ID = 7;
+
+function makeRace(
+  meetingKey: number,
+  round: number,
+  hasSprint = false,
+  dates: { start: string; end: string } = {
+    start: "2026-03-01T00:00:00Z",
+    end: "2026-03-03T00:00:00Z",
+  }
+): Race {
+  return {
+    meetingKey,
+    raceName: `Race ${round}`,
+    officialName: `Official Race ${round}`,
+    circuitShortName: `Circuit ${round}`,
+    countryName: "Country",
+    countryCode: "CC",
+    location: "Location",
+    dateStart: dates.start,
+    dateEnd: dates.end,
+    sprintDateEnd: hasSprint ? dates.start : null,
+    round,
+    hasSprint,
+  };
+}
+
+/** DB race id 501 -> meeting key 9001, 502 -> 9002. */
+const RACE_ID_TO_KEY = new Map<number, number>([
+  [501, 9001],
+  [502, 9002],
+]);
+
+function raceRow(
+  race_id: number,
+  status: string | null,
+  points_earned: number | null = null
+): UserPredictionRow {
+  return { race_id, status, points_earned };
+}
+
+describe("buildDashboardPredictions", () => {
+  describe("status", () => {
+    it("returns a pending entry with undefined points when the user has no rows", () => {
+      const [pred] = buildDashboardPredictions([makeRace(9001, 1)], [], [], RACE_ID_TO_KEY);
+      expect(pred).toEqual({
+        raceId: 9001,
+        raceName: "Race 1",
+        round: 1,
+        status: "pending",
+        top10: [],
+        pointsEarned: undefined,
+        maxPoints: 42,
+      });
+    });
+
+    it("is scored once the race prediction is scored, even when the sprint is pending", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1, true)],
+        [raceRow(501, "scored", 30)],
+        [],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.status).toBe("scored");
+    });
+
+    it("stays pending on a sprint weekend when only the race prediction is submitted", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1, true)],
+        [raceRow(501, "submitted")],
+        [],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.status).toBe("pending");
+    });
+
+    it("stays pending on a sprint weekend when only the sprint prediction is submitted", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1, true)],
+        [],
+        [raceRow(501, "submitted")],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.status).toBe("pending");
+    });
+
+    it("is submitted on a sprint weekend when race and sprint are both submitted", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1, true)],
+        [raceRow(501, "submitted")],
+        [raceRow(501, "submitted")],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.status).toBe("submitted");
+    });
+
+    it("is submitted on a sprint weekend when the race is submitted and the sprint already scored", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1, true)],
+        [raceRow(501, "submitted")],
+        [raceRow(501, "scored", 8)],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.status).toBe("submitted");
+    });
+
+    it("is submitted on a non-sprint weekend from the race prediction alone", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1, false)],
+        [raceRow(501, "submitted")],
+        [],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.status).toBe("submitted");
+    });
+  });
+
+  describe("points", () => {
+    it("sums race and sprint points on a sprint weekend", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1, true)],
+        [raceRow(501, "scored", 30)],
+        [raceRow(501, "scored", 12)],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.pointsEarned).toBe(42);
+    });
+
+    it("treats null race points as 0 when the sprint is scored", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1, true)],
+        [raceRow(501, "submitted", null)],
+        [raceRow(501, "scored", 8)],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.pointsEarned).toBe(8);
+    });
+
+    it("uses race points alone when the sprint has null points", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1, true)],
+        [raceRow(501, "scored", 25)],
+        [raceRow(501, "submitted", null)],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.pointsEarned).toBe(25);
+    });
+
+    it("keeps a scored 0 (not undefined)", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1)],
+        [raceRow(501, "scored", 0)],
+        [],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.pointsEarned).toBe(0);
+    });
+
+    it("is undefined when neither race nor sprint has points", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1, true)],
+        [raceRow(501, "submitted", null)],
+        [raceRow(501, "submitted", null)],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.pointsEarned).toBeUndefined();
+    });
+
+    it("ignores sprint points and status on a non-sprint weekend", () => {
+      const [pred] = buildDashboardPredictions(
+        [makeRace(9001, 1, false)],
+        [raceRow(501, "scored", 20)],
+        [raceRow(501, "scored", 99)],
+        RACE_ID_TO_KEY
+      );
+      expect(pred.pointsEarned).toBe(20);
+      expect(pred.status).toBe("scored");
+    });
+  });
+
+  it("counts sprint points from a row with a null status without affecting the combined status", () => {
+    const [pred] = buildDashboardPredictions(
+      [makeRace(9001, 1, true)],
+      [raceRow(501, "submitted")],
+      [raceRow(501, null, 5)],
+      RACE_ID_TO_KEY
+    );
+    expect(pred.pointsEarned).toBe(5);
+    expect(pred.status).toBe("pending"); // null sprint status is not "submitted"
+  });
+
+  it("ignores race and sprint rows whose race_id has no meeting-key mapping", () => {
+    const [pred] = buildDashboardPredictions(
+      [makeRace(9001, 1, true)],
+      [raceRow(999, "scored", 30)],
+      [raceRow(998, "scored", 12)],
+      RACE_ID_TO_KEY
+    );
+    expect(pred.status).toBe("pending");
+    expect(pred.pointsEarned).toBeUndefined();
+  });
+
+  it("returns one entry per race, matched by meeting key", () => {
+    const races = [makeRace(9001, 1), makeRace(9002, 2)];
+    const preds = buildDashboardPredictions(
+      races,
+      [raceRow(502, "scored", 15)],
+      [],
+      RACE_ID_TO_KEY
+    );
+    expect(preds).toHaveLength(2);
+    expect(preds[0]).toMatchObject({ raceId: 9001, status: "pending" });
+    expect(preds[1]).toMatchObject({ raceId: 9002, status: "scored", pointsEarned: 15 });
+  });
+});
+
+describe("fetchDashboardData", () => {
+  // Fixed "now": race 1 is in the past, race 2 in the future.
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-06-01T00:00:00Z"));
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  const PAST = { start: "2026-03-01T00:00:00Z", end: "2026-03-03T00:00:00Z" };
+  const FUTURE = { start: "2026-09-01T00:00:00Z", end: "2026-09-03T00:00:00Z" };
+  const RACES = [makeRace(9001, 1, true, PAST), makeRace(9002, 2, false, FUTURE)];
+
+  const DB_RACES = [
+    { id: 501, meeting_key: 9001 },
+    { id: 502, meeting_key: 9002 },
+  ];
+
+  function setupBase() {
+    const { supabase, mockTable } = createMockSupabase();
+    mockTable("seasons", { data: { id: SEASON_ID }, error: null });
+    mockTable("races", { data: DB_RACES, error: null });
+    return { supabase, mockTable };
+  }
+
+  it("assembles the full dashboard: profile, stats, leaderboard, predictions, calendar, next race", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable(
+      "profiles",
+      { data: { display_name: "Alice", avatar_url: "https://a/img.png" }, error: null },
+      {
+        data: [
+          { id: USER_ID, display_name: "Alice" },
+          { id: "u2", display_name: "Bob" },
+        ],
+        error: null,
+      }
+    );
+    mockTable("race_predictions", {
+      data: [raceRow(501, "scored", 30), raceRow(502, "submitted", null)],
+      error: null,
+    });
+    mockTable("sprint_predictions", {
+      data: [raceRow(501, "scored", 12)],
+      error: null,
+    });
+    mockTable("leaderboard", {
+      data: [
+        { user_id: USER_ID, total_points: 42, predictions_count: 2 },
+        { user_id: "u2", total_points: 70, predictions_count: 1 },
+      ],
+      error: null,
+    });
+
+    const data = await fetchDashboardData(supabase, USER_ID, RACES);
+
+    expect(data.profile).toEqual({
+      displayName: "Alice",
+      avatarUrl: "https://a/img.png",
+    });
+    expect(data.userStats).toEqual({ totalPoints: 42, rank: 2, totalUsers: 2 });
+
+    expect(data.leaderboard).toEqual([
+      { rank: 1, userId: "u2", displayName: "Bob", totalPoints: 70, predictionsCount: 1 },
+      { rank: 2, userId: USER_ID, displayName: "Alice", totalPoints: 42, predictionsCount: 2 },
+    ]);
+
+    expect(data.predictions).toHaveLength(2);
+    expect(data.predictions[0]).toMatchObject({
+      raceId: 9001,
+      status: "scored",
+      pointsEarned: 42, // 30 race + 12 sprint
+    });
+    expect(data.predictions[1]).toMatchObject({
+      raceId: 9002,
+      status: "submitted",
+      pointsEarned: undefined,
+    });
+
+    expect(data.calendarEntries.map((e) => e.race.round)).toEqual([1, 2]);
+    expect(data.calendarEntries.map((e) => e.predictionStatus)).toEqual([
+      "scored",
+      "submitted",
+    ]);
+
+    expect(data.nextRace?.meetingKey).toBe(9002);
+  });
+
+  it("slices the ranked leaderboard to the top 10 while totalUsers counts everyone", async () => {
+    const { supabase, mockTable } = setupBase();
+    const profiles = Array.from({ length: 12 }, (_, i) => ({
+      id: `u${String(i + 1).padStart(2, "0")}`,
+      display_name: `User ${String(i + 1).padStart(2, "0")}`,
+    }));
+    // u01 has the most points, descending from there; u12 (the current user) has none.
+    const totals = profiles.slice(0, 11).map((p, i) => ({
+      user_id: p.id,
+      total_points: 120 - i * 10,
+      predictions_count: 1,
+    }));
+    mockTable("profiles", { data: { display_name: "Me", avatar_url: null }, error: null }, {
+      data: profiles,
+      error: null,
+    });
+    mockTable("race_predictions", { data: [], error: null });
+    mockTable("sprint_predictions", { data: [], error: null });
+    mockTable("leaderboard", { data: totals, error: null });
+
+    const data = await fetchDashboardData(supabase, "u12", RACES);
+
+    expect(data.leaderboard).toHaveLength(10);
+    expect(data.leaderboard[0]).toMatchObject({ rank: 1, userId: "u01", totalPoints: 120 });
+    expect(data.leaderboard[9]).toMatchObject({ rank: 10, userId: "u10", totalPoints: 30 });
+    // Current user is outside the top 10 but still ranked and counted.
+    expect(data.userStats).toEqual({ totalPoints: 0, rank: 12, totalUsers: 12 });
+  });
+
+  it("shares ranks between tied totals (competition ranking)", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("profiles", { data: null, error: null }, {
+      data: [
+        { id: USER_ID, display_name: "Alice" },
+        { id: "u2", display_name: "Bob" },
+        { id: "u3", display_name: "Cara" },
+      ],
+      error: null,
+    });
+    mockTable("race_predictions", { data: [], error: null });
+    mockTable("sprint_predictions", { data: [], error: null });
+    mockTable("leaderboard", {
+      data: [
+        { user_id: USER_ID, total_points: 50, predictions_count: 1 },
+        { user_id: "u2", total_points: 50, predictions_count: 1 },
+        { user_id: "u3", total_points: 10, predictions_count: 1 },
+      ],
+      error: null,
+    });
+
+    const data = await fetchDashboardData(supabase, USER_ID, RACES);
+
+    expect(data.leaderboard.map((e) => e.rank)).toEqual([1, 1, 3]);
+    expect(data.userStats.rank).toBe(1);
+  });
+
+  it("gives a user without a leaderboard row 0 points but a real rank", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("profiles", { data: { display_name: "Newbie", avatar_url: null }, error: null }, {
+      data: [
+        { id: USER_ID, display_name: "Newbie" },
+        { id: "u2", display_name: "Veteran" },
+      ],
+      error: null,
+    });
+    mockTable("race_predictions", { data: [], error: null });
+    mockTable("sprint_predictions", { data: [], error: null });
+    mockTable("leaderboard", {
+      data: [{ user_id: "u2", total_points: 55, predictions_count: 2 }],
+      error: null,
+    });
+
+    const data = await fetchDashboardData(supabase, USER_ID, RACES);
+
+    expect(data.userStats).toEqual({ totalPoints: 0, rank: 2, totalUsers: 2 });
+    expect(data.leaderboard[1]).toMatchObject({ userId: USER_ID, totalPoints: 0 });
+  });
+
+  it("handles empty profiles/leaderboard and no races gracefully", async () => {
+    const { supabase, mockTable } = createMockSupabase();
+    mockTable("profiles", { data: null, error: null }, { data: [], error: null });
+    mockTable("race_predictions", { data: null, error: null });
+    mockTable("sprint_predictions", { data: null, error: null });
+    mockTable("seasons", { data: null, error: null });
+    mockTable("leaderboard", { data: null, error: null });
+    mockTable("races", { data: null, error: null });
+
+    const data = await fetchDashboardData(supabase, USER_ID, []);
+
+    expect(data.profile).toEqual({ displayName: null, avatarUrl: null });
+    expect(data.userStats).toEqual({ totalPoints: 0, rank: 0, totalUsers: 0 });
+    expect(data.leaderboard).toEqual([]);
+    expect(data.predictions).toEqual([]);
+    expect(data.calendarEntries).toEqual([]);
+    expect(data.nextRace).toBeNull();
+  });
+
+  /** Wraps supabase.from to record .eq() filters applied to the "races" query. */
+  interface LooseChain {
+    eq: (col: string, val: unknown) => unknown;
+  }
+  interface LooseClient {
+    from: (table: string) => { select: (cols?: string) => LooseChain };
+  }
+
+  function spyOnRacesFilters(supabase: ReturnType<typeof createMockSupabase>["supabase"]) {
+    const eqCalls: [string, unknown][] = [];
+    const client = supabase as unknown as LooseClient;
+    const originalFrom = client.from.bind(client);
+    client.from = (table: string) => {
+      const api = originalFrom(table);
+      if (table !== "races") return api;
+      return {
+        ...api,
+        select: (cols?: string) => {
+          const chain = api.select(cols);
+          const originalEq = chain.eq.bind(chain);
+          chain.eq = (col: string, val: unknown) => {
+            eqCalls.push([col, val]);
+            return originalEq(col, val);
+          };
+          return chain;
+        },
+      };
+    };
+    return eqCalls;
+  }
+
+  it("scopes the raceId→meetingKey races query to the current season id", async () => {
+    const { supabase, mockTable } = setupBase();
+    mockTable("profiles", { data: null, error: null }, { data: [], error: null });
+    mockTable("race_predictions", { data: [], error: null });
+    mockTable("sprint_predictions", { data: [], error: null });
+    mockTable("leaderboard", { data: [], error: null });
+    const eqCalls = spyOnRacesFilters(supabase);
+
+    await fetchDashboardData(supabase, USER_ID, RACES);
+
+    expect(eqCalls).toEqual([["season_id", SEASON_ID]]);
+  });
+
+  it("falls back to an impossible season id (-1) when there is no current season", async () => {
+    const { supabase, mockTable } = createMockSupabase();
+    mockTable("seasons", { data: null, error: null });
+    mockTable("races", { data: [], error: null });
+    mockTable("profiles", { data: null, error: null }, { data: [], error: null });
+    mockTable("race_predictions", { data: [raceRow(501, "scored", 30)], error: null });
+    mockTable("sprint_predictions", { data: [], error: null });
+    mockTable("leaderboard", { data: [], error: null });
+    const eqCalls = spyOnRacesFilters(supabase);
+
+    const data = await fetchDashboardData(supabase, USER_ID, RACES);
+
+    expect(eqCalls).toEqual([["season_id", -1]]);
+    // With an empty mapping the scored row cannot be attributed to any race.
+    expect(data.predictions.map((p) => p.status)).toEqual(["pending", "pending"]);
+  });
+});

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -14,11 +14,10 @@ import {
   StandingsCard,
   UserSummaryCard,
 } from "@/components/dashboard";
-import { fetchRacesFromDb, getNextRace } from "@/lib/races";
-import { getRaceCalendarEntries } from "@f1/shared/lib/race-utils";
+import { fetchRacesFromDb } from "@/lib/races";
+import { fetchDashboardData } from "@f1/shared/lib/dashboard";
 import { fetchAchievementsData } from "@/lib/achievements";
 import { fetchChampionshipStandings } from "@f1/shared/lib/championship-standings";
-import type { UserStats, LeaderboardEntry, RacePrediction, PredictionStatus } from "@f1/shared/types";
 
 export default async function Home() {
   const supabase = await createClient();
@@ -34,162 +33,17 @@ export default async function Home() {
     user.user_metadata?.full_name || user.email?.split("@")[0] || "Driver";
   const fallbackAvatar = user.user_metadata?.avatar_url;
 
-  const { data: profileRow } = await supabase
-    .from("profiles")
-    .select("display_name, avatar_url")
-    .eq("id", user.id)
-    .single();
-
-  const displayName = profileRow?.display_name ?? fallbackName;
-  const avatarUrl = profileRow?.avatar_url ?? fallbackAvatar;
-
-  const { data: leaderboardRow } = await supabase
-    .from("leaderboard")
-    .select("total_points, rank, predictions_count, best_race_points, perfect_podiums")
-    .eq("user_id", user.id)
-    .single();
-
-  const { data: racePredictions } = await supabase
-    .from("race_predictions")
-    .select("race_id, status, points_earned")
-    .eq("user_id", user.id);
-
-  const { data: sprintPredictions } = await supabase
-    .from("sprint_predictions")
-    .select("race_id, status, points_earned")
-    .eq("user_id", user.id);
-
-  // Fetch current season to ensure the raceId→meetingKey mapping is season-aware
-  const { data: currentSeason } = await supabase
-    .from("seasons")
-    .select("id")
-    .eq("is_current", true)
-    .single();
-
-  // Build mapping: DB race ID -> meeting key
-  const { data: dbRaces } = await supabase
-    .from("races")
-    .select("id, meeting_key")
-    .eq("season_id", currentSeason?.id ?? -1);
-
-  const raceIdToMeetingKey = new Map<number, number>();
-  for (const r of dbRaces ?? []) {
-    raceIdToMeetingKey.set(r.id, r.meeting_key);
-  }
-
-  // All profiles = every registered user (source of truth for total count + leaderboard)
-  const { data: allProfiles } = await supabase
-    .from("profiles")
-    .select("id, display_name")
-    .order("display_name", { ascending: true });
-
-  const { data: leaderboardRows } = await supabase
-    .from("leaderboard")
-    .select("user_id, total_points, predictions_count");
-
-  const leaderboardMap = new Map(
-    (leaderboardRows ?? []).map((r) => [r.user_id, r])
-  );
-
-  const totalUsers = (allProfiles ?? []).length;
-
-  // Build full ranked list (mirrors leaderboard page logic)
-  type RankedEntry = LeaderboardEntry & { _points: number };
-  const unsorted: RankedEntry[] = (allProfiles ?? []).map((p) => {
-    const lb = leaderboardMap.get(p.id);
-    return {
-      rank: 0,
-      userId: p.id,
-      displayName: p.display_name ?? "Driver",
-      totalPoints: lb?.total_points ?? 0,
-      predictionsCount: lb?.predictions_count ?? 0,
-      _points: lb?.total_points ?? 0,
-    };
-  });
-
-  unsorted.sort((a, b) =>
-    b._points !== a._points
-      ? b._points - a._points
-      : a.displayName.localeCompare(b.displayName)
-  );
-
-  // Assign shared ranks then take top 10
-  const allRanked: LeaderboardEntry[] = unsorted.reduce<LeaderboardEntry[]>((acc, e, i) => {
-    const rank = i === 0 || e._points < unsorted[i - 1]._points ? i + 1 : acc[i - 1].rank;
-    acc.push({ rank, userId: e.userId, displayName: e.displayName, totalPoints: e.totalPoints, predictionsCount: e.predictionsCount });
-    return acc;
-  }, []);
-
-  const leaderboard = allRanked.slice(0, 10);
-
-  // Current user's rank from the full ranked list
-  const currentUserRank = allRanked.find((e) => e.userId === user.id)?.rank ?? 0;
-
-  const userStats: UserStats = {
-    totalPoints: leaderboardRow?.total_points ?? 0,
-    rank: currentUserRank,
-    totalUsers,
-  };
-
-  // Fetch races with live DB datetimes
+  // Fetch races with live DB datetimes, then assemble the dashboard from shared logic
   const races = await fetchRacesFromDb();
+  const { profile, userStats, leaderboard, calendarEntries, nextRace } =
+    await fetchDashboardData(supabase, user.id, races);
 
-  const sprintEarningsByMeetingKey = new Map<number, number>();
-  const sprintStatusByMeetingKey = new Map<number, PredictionStatus>();
-  for (const sp of sprintPredictions ?? []) {
-    const meetingKey = raceIdToMeetingKey.get(sp.race_id);
-    if (meetingKey === undefined) continue;
-    if (sp.points_earned != null) sprintEarningsByMeetingKey.set(meetingKey, sp.points_earned);
-    if (sp.status) sprintStatusByMeetingKey.set(meetingKey, sp.status as PredictionStatus);
-  }
-
-  const predictions: RacePrediction[] = races.map((race) => {
-    const pred = (racePredictions ?? []).find((p) => {
-      const meetingKey = raceIdToMeetingKey.get(p.race_id);
-      return meetingKey === race.meetingKey;
-    });
-    const racePts = pred?.points_earned ?? null;
-    const sprintPts = race.hasSprint ? (sprintEarningsByMeetingKey.get(race.meetingKey) ?? null) : null;
-    const totalPts =
-      racePts !== null || sprintPts !== null
-        ? (racePts ?? 0) + (sprintPts ?? 0)
-        : undefined;
-
-    // Combined status: for sprint weekends, "submitted" requires both race and sprint predictions submitted.
-    const raceStatus = (pred?.status as PredictionStatus | undefined) ?? "pending";
-    const sprintStatus = sprintStatusByMeetingKey.get(race.meetingKey) ?? "pending";
-    let combinedStatus: PredictionStatus;
-    if (raceStatus === "scored") {
-      combinedStatus = "scored";
-    } else {
-      const raceDone = raceStatus === "submitted";
-      const sprintDone = !race.hasSprint || sprintStatus === "submitted" || sprintStatus === "scored";
-      combinedStatus = raceDone && sprintDone ? "submitted" : "pending";
-    }
-
-    return {
-      raceId: race.meetingKey,
-      raceName: race.raceName,
-      round: race.round,
-      status: combinedStatus,
-      top10: [],
-      pointsEarned: totalPts,
-      maxPoints: 42,
-    };
-  });
+  const displayName = profile.displayName ?? fallbackName;
+  const avatarUrl = profile.avatarUrl ?? fallbackAvatar;
 
   const { achievements, earnedIds: earnedAchievementIds } = await fetchAchievementsData(supabase, user.id);
 
   const championshipStandings = await fetchChampionshipStandings(supabase);
-
-  const nextRace = getNextRace(races);
-
-  // Build prediction status map for the calendar
-  const predictionStatusByMeetingKey = new Map<number, PredictionStatus>();
-  for (const pred of predictions) {
-    predictionStatusByMeetingKey.set(pred.raceId, pred.status);
-  }
-  const calendarEntries = getRaceCalendarEntries(races, predictionStatusByMeetingKey);
 
   return (
     <div className="flex min-h-screen flex-col">

--- a/docs/mobile-migration/decisions.md
+++ b/docs/mobile-migration/decisions.md
@@ -2,6 +2,33 @@
 
 Running record of decisions made after the initial plan. Newest first.
 
+## 2026-07-12 — Home dashboard screen (Phase 4a)
+
+**Decision:** The mobile Home tab replaces the Phase-1 smoke screen with the real dashboard as a
+vertical card stack (no bento grid on a phone): UserSummaryCard, NextRaceCountdown /
+NoUpcomingRaces (1s-tick countdown to the active deadline, same `getActiveDeadline` semantics as
+web), compact StandingsCard and LeaderboardCard that **navigate to the existing tabs** (per the
+plan — no re-implementation), and PointSystemCard / RaceCalendarCard opening **bottom sheets**
+(same slide-modal pattern as `TeamPickerModal`). **NewPointsSystemBanner and PlaceholderCard are
+not ported** — the banner announced a points-system change to existing web users, meaningless in
+a brand-new app. A temporary sign-out button stays at the bottom of Home until the Profile screen
+(Phase 4c) takes it over.
+
+**Shared extraction:** the ~160-line dashboard assembly inlined in `apps/web/app/page.tsx` moved
+to `packages/shared/lib/dashboard.ts` — pure `buildDashboardPredictions` (per-race combined
+race+sprint status/points keyed by meeting key) plus service `fetchDashboardData(supabase,
+userId, races)` (caller passes already-fetched `Race[]`, like `fetchDetailedLeaderboard`).
+It reuses `buildLeaderboardEntries`/`rankLeaderboardEntries` instead of the page's duplicated
+ranking code, drops the page's redundant single-user leaderboard query, and parallelizes the
+independent queries; web output is unchanged and the module has 100%-line unit coverage.
+Achievements and standings stay on their existing shared fetchers, called directly.
+
+**Mobile-specific deviations:** the UserSummaryCard shows an earned/total progress bar instead of
+the web's lucide icon previews (the icon map is web-only by design); point-system examples are
+tap-to-expand rows instead of hover tooltips; the calendar sheet opens auto-scrolled to the next
+race via `initialScrollIndex`. Zero new translation keys — the web dashboard keys covered
+everything (en/es parity unchanged at 482).
+
 ## 2026-07-11 — Sprint/champion tabs + results comparison (Phase 3, final iteration)
 
 **Decision:** The mobile Predictions screen hosts a **Race / Sprint / Champion segmented

--- a/docs/mobile-migration/mobile-migration-plan.md
+++ b/docs/mobile-migration/mobile-migration-plan.md
@@ -8,8 +8,8 @@
 > | 0 — Monorepo restructure | ✅ Done (PR #81, 2026-07-08) |
 > | 1 — Mobile scaffold | ✅ Done (PR #82, 2026-07-08 — Expo SDK 54) |
 > | 2 — Auth | ✅ Done (PR #84, 2026-07-10 — email/password + Google; **Apple sign-in deferred**, see decisions.md) |
-> | 3 — Core loop | ✅ Code complete (pending device verification). Race prediction screen (PR #85, 2026-07-11 — incl. Bearer-token API auth). Leaderboard + standings screens (PR #86, 2026-07-11 — incl. bottom tab navigator + shared `fetchDetailedLeaderboard` extraction). Sprint + champion tabs and the results-comparison display (2026-07-11 — incl. shared sprint/champion/results fetcher extractions, see decisions.md). **Next:** verify the new tabs in Expo Go on-device, then Phase 4 |
-> | 4a — Home dashboard screen | ⬜ Not started |
+> | 3 — Core loop | ✅ Done (verified in Expo Go on-device, 2026-07-12). Race prediction screen (PR #85, 2026-07-11 — incl. Bearer-token API auth). Leaderboard + standings screens (PR #86, 2026-07-11 — incl. bottom tab navigator + shared `fetchDetailedLeaderboard` extraction). Sprint + champion tabs and the results-comparison display (PR #87, 2026-07-11 — incl. shared sprint/champion/results fetcher extractions, see decisions.md) |
+> | 4a — Home dashboard screen | ✅ Code complete (2026-07-12 — incl. shared `fetchDashboardData` extraction, bottom-sheet point system + race calendar, see decisions.md). **Next:** verify in Expo Go on-device, then Phase 4b |
 > | 4b — Achievements screen | ⬜ Not started |
 > | 4c — Profile & account settings | ⬜ Not started |
 > | 5 — Ship (EAS Submit) | ⬜ Not started |

--- a/packages/shared/lib/dashboard.ts
+++ b/packages/shared/lib/dashboard.ts
@@ -1,0 +1,209 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  LeaderboardEntry,
+  Race,
+  RacePrediction,
+  PredictionStatus,
+  UserStats,
+} from "../types";
+import {
+  buildLeaderboardEntries,
+  rankLeaderboardEntries,
+  type LeaderboardProfileRow,
+  type LeaderboardTotalsRow,
+} from "./leaderboard";
+import { getNextRace, getRaceCalendarEntries, type RaceCalendarEntry } from "./race-utils";
+
+/** Per-user prediction row shape shared by race and sprint predictions. */
+export interface UserPredictionRow {
+  race_id: number;
+  status: string | null;
+  points_earned: number | null;
+}
+
+/**
+ * Builds one dashboard prediction summary per race by merging the user's race
+ * and sprint prediction rows (keyed via the raceId → meetingKey map):
+ * - points: race + sprint points combined; `undefined` when neither is scored.
+ * - status: "scored" once the race prediction is scored; "submitted" only when
+ *   the race prediction is submitted AND (for sprint weekends) the sprint
+ *   prediction is submitted or scored; otherwise "pending".
+ * Pure function.
+ */
+export function buildDashboardPredictions(
+  races: Race[],
+  racePredictionRows: UserPredictionRow[],
+  sprintPredictionRows: UserPredictionRow[],
+  raceIdToMeetingKey: Map<number, number>
+): RacePrediction[] {
+  const sprintEarningsByMeetingKey = new Map<number, number>();
+  const sprintStatusByMeetingKey = new Map<number, PredictionStatus>();
+  for (const sp of sprintPredictionRows) {
+    const meetingKey = raceIdToMeetingKey.get(sp.race_id);
+    if (meetingKey === undefined) continue;
+    if (sp.points_earned != null) sprintEarningsByMeetingKey.set(meetingKey, sp.points_earned);
+    if (sp.status) sprintStatusByMeetingKey.set(meetingKey, sp.status as PredictionStatus);
+  }
+
+  return races.map((race) => {
+    const pred = racePredictionRows.find(
+      (p) => raceIdToMeetingKey.get(p.race_id) === race.meetingKey
+    );
+    const racePts = pred?.points_earned ?? null;
+    const sprintPts = race.hasSprint ? (sprintEarningsByMeetingKey.get(race.meetingKey) ?? null) : null;
+    const totalPts =
+      racePts !== null || sprintPts !== null
+        ? (racePts ?? 0) + (sprintPts ?? 0)
+        : undefined;
+
+    // Combined status: for sprint weekends, "submitted" requires both race and sprint predictions submitted.
+    const raceStatus = (pred?.status as PredictionStatus | undefined) ?? "pending";
+    const sprintStatus = sprintStatusByMeetingKey.get(race.meetingKey) ?? "pending";
+    let combinedStatus: PredictionStatus;
+    if (raceStatus === "scored") {
+      combinedStatus = "scored";
+    } else {
+      const raceDone = raceStatus === "submitted";
+      const sprintDone = !race.hasSprint || sprintStatus === "submitted" || sprintStatus === "scored";
+      combinedStatus = raceDone && sprintDone ? "submitted" : "pending";
+    }
+
+    return {
+      raceId: race.meetingKey,
+      raceName: race.raceName,
+      round: race.round,
+      status: combinedStatus,
+      top10: [],
+      pointsEarned: totalPts,
+      maxPoints: 42,
+    };
+  });
+}
+
+/** The user's raw profile row — the caller applies auth-metadata fallbacks. */
+export interface DashboardProfile {
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+/** Everything the home dashboard needs (achievements and championship standings excluded — they have dedicated shared fetchers). */
+export interface DashboardData {
+  profile: DashboardProfile;
+  userStats: UserStats;
+  /** Top 10 of the full ranked leaderboard (shared ranks, alphabetical tiebreak). */
+  leaderboard: LeaderboardEntry[];
+  /** Per-race combined race + sprint prediction summaries, one per passed race. */
+  predictions: RacePrediction[];
+  calendarEntries: RaceCalendarEntry[];
+  nextRace: Race | null;
+}
+
+/**
+ * Fetches and assembles the home dashboard data for one user: profile row,
+ * ranked leaderboard top 10, the user's rank / total registered users, per-race
+ * combined prediction summaries, calendar entries, and the next race.
+ *
+ * `races` is the already-fetched current-season calendar (via the shared
+ * `fetchRaces`) so callers reuse it for rendering. The caller injects the
+ * Supabase client.
+ */
+export async function fetchDashboardData(
+  supabase: SupabaseClient,
+  userId: string,
+  races: Race[]
+): Promise<DashboardData> {
+  const [
+    { data: profileRow },
+    { data: racePredictions },
+    { data: sprintPredictions },
+    { data: currentSeason },
+    { data: allProfiles },
+    { data: leaderboardRows },
+  ] = await Promise.all([
+    supabase
+      .from("profiles")
+      .select("display_name, avatar_url")
+      .eq("id", userId)
+      .single(),
+    supabase
+      .from("race_predictions")
+      .select("race_id, status, points_earned")
+      .eq("user_id", userId),
+    supabase
+      .from("sprint_predictions")
+      .select("race_id, status, points_earned")
+      .eq("user_id", userId),
+    // Current season, so the raceId→meetingKey mapping is season-aware
+    supabase.from("seasons").select("id").eq("is_current", true).single(),
+    // Every registered user — the source of truth for total count + leaderboard
+    supabase
+      .from("profiles")
+      .select("id, display_name")
+      .order("display_name", { ascending: true }),
+    supabase.from("leaderboard").select("user_id, total_points, predictions_count"),
+  ]);
+
+  // Build mapping: DB race ID -> meeting key
+  const { data: dbRaces } = await supabase
+    .from("races")
+    .select("id, meeting_key")
+    .eq("season_id", currentSeason?.id ?? -1);
+
+  const raceIdToMeetingKey = new Map<number, number>();
+  for (const r of dbRaces ?? []) {
+    raceIdToMeetingKey.set(r.id, r.meeting_key);
+  }
+
+  // Full ranked leaderboard (no per-race breakdown needed → empty race keys)
+  const unranked = buildLeaderboardEntries(
+    (allProfiles ?? []) as LeaderboardProfileRow[],
+    (leaderboardRows ?? []) as LeaderboardTotalsRow[],
+    {},
+    []
+  );
+  const allRanked = rankLeaderboardEntries(unranked);
+
+  const leaderboard: LeaderboardEntry[] = allRanked
+    .slice(0, 10)
+    .map(({ rank, userId: id, displayName, totalPoints, predictionsCount }) => ({
+      rank,
+      userId: id,
+      displayName,
+      totalPoints,
+      predictionsCount,
+    }));
+
+  const currentUserEntry = allRanked.find((e) => e.userId === userId);
+
+  const userStats: UserStats = {
+    totalPoints: currentUserEntry?.totalPoints ?? 0,
+    rank: currentUserEntry?.rank ?? 0,
+    totalUsers: (allProfiles ?? []).length,
+  };
+
+  const predictions = buildDashboardPredictions(
+    races,
+    (racePredictions ?? []) as UserPredictionRow[],
+    (sprintPredictions ?? []) as UserPredictionRow[],
+    raceIdToMeetingKey
+  );
+
+  // Prediction status map for the calendar
+  const predictionStatusByMeetingKey = new Map<number, PredictionStatus>();
+  for (const pred of predictions) {
+    predictionStatusByMeetingKey.set(pred.raceId, pred.status);
+  }
+  const calendarEntries = getRaceCalendarEntries(races, predictionStatusByMeetingKey);
+
+  return {
+    profile: {
+      displayName: profileRow?.display_name ?? null,
+      avatarUrl: profileRow?.avatar_url ?? null,
+    },
+    userStats,
+    leaderboard,
+    predictions,
+    calendarEntries,
+    nextRace: getNextRace(races) ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 4a of the mobile migration: the mobile Home tab replaces the Phase-1 smoke screen with the real dashboard, following the established shared-extraction pattern.

### Shared extraction (`packages/shared/lib/dashboard.ts`)
- Pure `buildDashboardPredictions` — per-race combined race+sprint prediction status/points keyed by meeting key.
- Service `fetchDashboardData(supabase, userId, races)` — profile, user stats (rank/total users), ranked top-10 leaderboard (reusing `buildLeaderboardEntries`/`rankLeaderboardEntries` instead of the page's duplicated ranking), calendar entries, next race. Independent queries parallelized; season-scoped raceId→meetingKey mapping preserved.
- `apps/web/app/page.tsx` now consumes it — JSX and behavior unchanged.

### Mobile Home screen (`apps/mobile`)
- UserSummaryCard (points, rank, achievements progress bar), NextRaceCountdown / NoUpcomingRaces (live 1s countdown to the active deadline + Make Prediction CTA).
- Compact StandingsCard / LeaderboardCard that navigate to the existing tabs (per plan — summaries, not re-implementations; standings query key shared with the Standings tab cache).
- PointSystemCard + RaceCalendarCard open bottom sheets (TeamPickerModal pattern); calendar auto-scrolls to the next race.
- NewPointsSystemBanner and PlaceholderCard intentionally not ported; temporary sign-out button stays on Home until Phase 4c (Profile).
- Zero new translation keys — existing web dashboard keys covered everything (en/es parity 482/482).

### Tests & gates
- 23 new unit tests, 100% line coverage on the new shared module.
- `tsc --noEmit` clean (web + mobile), 429 tests passing, lint 0 errors, translation parity intact.

### Docs
- Migration plan: Phase 3 marked verified on-device; Phase 4a code complete (pending Expo Go verification).
- New decision-log entry for the 4a design choices.