### PR TITLE
feat: mobile achievements screen (Phase 4b)

### DIFF
--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -5,8 +5,8 @@ import { useLanguage } from "@/providers/LanguageProvider";
 
 /**
  * Bottom tab navigator for the signed-in app: Home, Predictions,
- * Leaderboard and Standings. Uses the same F1 dark theme as the previous
- * stack header (Graphite backgrounds, Crimson active tint).
+ * Leaderboard, Standings and Achievements. Uses the same F1 dark theme as
+ * the previous stack header (Graphite backgrounds, Crimson active tint).
  */
 export default function AppLayout() {
   const { t } = useLanguage();
@@ -48,6 +48,13 @@ export default function AppLayout() {
         options={{
           title: t.nav.standings,
           tabBarIcon: ({ color, size }) => <Ionicons name="trophy" size={size} color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="achievements"
+        options={{
+          title: t.nav.achievements,
+          tabBarIcon: ({ color, size }) => <Ionicons name="ribbon" size={size} color={color} />,
         }}
       />
     </Tabs>

--- a/apps/mobile/src/app/(app)/achievements.tsx
+++ b/apps/mobile/src/app/(app)/achievements.tsx
@@ -1,0 +1,144 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } from "react-native";
+import { buildProgressMap, fetchUserProgressData } from "@f1/shared/lib/achievement-calculator";
+import { fetchAchievementsData } from "@f1/shared/lib/achievements";
+import type { AchievementCategory } from "@f1/shared/types";
+
+import { AchievementCard } from "@/components/achievements/AchievementCard";
+import { AchievementsHeader } from "@/components/achievements/AchievementsHeader";
+import { CategoryChips, type CategoryFilter } from "@/components/achievements/CategoryChips";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/providers/AuthProvider";
+import { useLanguage } from "@/providers/LanguageProvider";
+
+const CATEGORIES: AchievementCategory[] = ["predictions", "accuracy", "milestones", "special"];
+
+/**
+ * Achievements screen (Phase 4b): ports the web achievements page — header
+ * card with overall progress, category filter chips, and the earned/locked
+ * achievement list with per-achievement progress bars on locked cards.
+ */
+export default function AchievementsScreen() {
+  const { t } = useLanguage();
+  const { user } = useAuth();
+  const [activeCategory, setActiveCategory] = useState<CategoryFilter>("all");
+  const [refreshing, setRefreshing] = useState(false);
+
+  const userId = user?.id;
+
+  // Same query key as the Home dashboard so both screens share the cache.
+  const achievementsQuery = useQuery({
+    queryKey: ["achievements", userId],
+    queryFn: () => fetchAchievementsData(supabase, userId!),
+    enabled: Boolean(userId),
+  });
+
+  const progressQuery = useQuery({
+    queryKey: ["achievementProgress", userId],
+    queryFn: () => fetchUserProgressData(supabase, userId!),
+    enabled: Boolean(userId),
+  });
+
+  async function handleRefresh() {
+    setRefreshing(true);
+    try {
+      await Promise.all([achievementsQuery.refetch(), progressQuery.refetch()]);
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  const loadError = achievementsQuery.error ?? progressQuery.error;
+  const isPending = Boolean(userId) && (achievementsQuery.isPending || progressQuery.isPending);
+
+  if (loadError) {
+    return (
+      <View className="flex-1 items-center justify-center gap-4 bg-f1-black p-6">
+        <Text className="text-center text-sm text-f1-white/70">{t.predictionsPage.loadError}</Text>
+        <Pressable
+          onPress={() => {
+            achievementsQuery.refetch();
+            progressQuery.refetch();
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={t.predictionsPage.retry}
+          className="min-h-11 items-center justify-center rounded-lg bg-f1-red px-6 active:bg-f1-red-hover"
+        >
+          <Text className="font-semibold text-white">{t.predictionsPage.retry}</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const data = achievementsQuery.data;
+  const progress = progressQuery.data;
+
+  if (isPending || !data || !progress) {
+    return (
+      <View className="flex-1 items-center justify-center bg-f1-black p-6">
+        <ActivityIndicator color="#CF2637" />
+      </View>
+    );
+  }
+
+  const { achievements, earnedIds } = data;
+  const earnedSet = new Set(earnedIds);
+  const progressMap = buildProgressMap(achievements, progress);
+
+  const categoryLabels: Record<AchievementCategory, string> = {
+    predictions: t.achievementsPage.categoryPredictions,
+    accuracy: t.achievementsPage.categoryAccuracy,
+    milestones: t.achievementsPage.categoryMilestones,
+    special: t.achievementsPage.categorySpecial,
+  };
+
+  const chipItems = [
+    { value: "all" as const, label: t.achievementsPage.all, count: achievements.length },
+    ...CATEGORIES.map((cat) => ({
+      value: cat,
+      label: categoryLabels[cat],
+      count: achievements.filter((a) => a.category === cat).length,
+    })),
+  ];
+
+  const filtered =
+    activeCategory === "all"
+      ? achievements
+      : achievements.filter((a) => a.category === activeCategory);
+
+  return (
+    <ScrollView
+      className="flex-1 bg-f1-black"
+      contentContainerClassName="gap-4 p-4"
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor="#CF2637" />
+      }
+    >
+      <AchievementsHeader earnedCount={earnedIds.length} totalCount={achievements.length} />
+
+      <CategoryChips items={chipItems} active={activeCategory} onSelect={setActiveCategory} />
+
+      {filtered.length > 0 ? (
+        <View className="overflow-hidden rounded-2xl border border-f1-white/10 bg-f1-white/5">
+          {filtered.map((achievement, index) => (
+            <AchievementCard
+              key={achievement.id}
+              achievement={achievement}
+              isEarned={earnedSet.has(achievement.id)}
+              categoryLabel={categoryLabels[achievement.category]}
+              progress={earnedSet.has(achievement.id) ? undefined : progressMap[achievement.id]}
+              isLast={index === filtered.length - 1}
+            />
+          ))}
+        </View>
+      ) : (
+        <View className="items-center gap-2 rounded-2xl border border-f1-white/10 bg-f1-white/5 py-12">
+          <Ionicons name="ribbon" size={24} color="#F7F7F74D" />
+          <Text className="text-sm text-f1-white/50">{t.achievementsPage.noAchievements}</Text>
+        </View>
+      )}
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/components/achievements/AchievementCard.tsx
+++ b/apps/mobile/src/components/achievements/AchievementCard.tsx
@@ -1,0 +1,101 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
+
+import type { Achievement } from "@f1/shared/types";
+
+import { getAchievementIconName } from "@/lib/achievement-icons";
+import { getCategoryStyle } from "@/lib/achievement-styles";
+
+/**
+ * Single achievement row (ports the web bento cell): earned cards show the
+ * colored category icon plus a green check; locked cards show a lock icon at
+ * 60% opacity with muted text and, when progress data exists, a per-
+ * achievement progress bar with "current / max".
+ */
+export function AchievementCard({
+  achievement,
+  isEarned,
+  categoryLabel,
+  progress,
+  isLast = false,
+}: {
+  achievement: Achievement;
+  isEarned: boolean;
+  categoryLabel: string;
+  progress?: { current: number; max: number };
+  /** Skips the bottom divider on the list's last row. */
+  isLast?: boolean;
+}) {
+  const style = getCategoryStyle(achievement.category);
+  const fill = progress ? Math.min(progress.current / progress.max, 1) * 100 : 0;
+
+  return (
+    <View
+      className={`flex-row items-start gap-3 p-4 ${isLast ? "" : "border-b border-f1-white/10"} ${
+        isEarned ? "" : "opacity-60"
+      }`}
+    >
+      {/* Icon */}
+      <View
+        className={`h-11 w-11 items-center justify-center rounded-xl ${
+          isEarned ? style.bgClass : "bg-f1-white/10"
+        }`}
+      >
+        {isEarned ? (
+          <Ionicons name={getAchievementIconName(achievement.slug)} size={18} color={style.hex} />
+        ) : (
+          <Ionicons name="lock-closed" size={16} color="#F7F7F766" />
+        )}
+      </View>
+
+      {/* Text */}
+      <View className="min-w-0 flex-1">
+        <View className="flex-row items-center gap-2">
+          <Text
+            className={`text-xs font-semibold ${isEarned ? "text-f1-white" : "text-f1-white/50"}`}
+          >
+            {achievement.name}
+          </Text>
+          {isEarned ? (
+            <View className="h-4 w-4 items-center justify-center rounded-full bg-f1-green/20">
+              <Ionicons name="checkmark" size={10} color="#44AF69" />
+            </View>
+          ) : null}
+        </View>
+        <Text className="mt-0.5 text-[10px] leading-4 text-f1-white/50">
+          {achievement.description}
+        </Text>
+        <View className="mt-1.5 flex-row">
+          <View className={`rounded-md px-1.5 py-0.5 ${style.bgClass}`}>
+            <Text className={`text-[9px] font-medium uppercase tracking-wider ${style.textClass}`}>
+              {categoryLabel}
+            </Text>
+          </View>
+        </View>
+
+        {/* Progress bar — only on locked cards with known progress */}
+        {!isEarned && progress ? (
+          <View className="mt-2 gap-0.5">
+            <View
+              className="h-1 w-full overflow-hidden rounded-full bg-f1-white/10"
+              accessibilityRole="progressbar"
+              accessibilityLabel={`${achievement.name}: ${progress.current} / ${progress.max}`}
+              accessibilityValue={{ min: 0, max: progress.max, now: progress.current }}
+            >
+              {/* Fill color comes from the category hex: a class built at
+                  runtime (e.g. "bg-f1-blue") would not be compiled by
+                  NativeWind since it never appears literally in source. */}
+              <View
+                className="h-full rounded-full"
+                style={{ width: `${fill}%`, backgroundColor: style.hex }}
+              />
+            </View>
+            <Text className={`text-right text-[9px] tabular-nums ${style.textClass}`}>
+              {progress.current} / {progress.max}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/achievements/AchievementsHeader.tsx
+++ b/apps/mobile/src/components/achievements/AchievementsHeader.tsx
@@ -1,0 +1,47 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
+
+import { useLanguage } from "@/providers/LanguageProvider";
+
+/**
+ * Header card for the Achievements screen: title, "X of Y unlocked" counter
+ * and the purple overall progress bar (ports the web AchievementsContent
+ * header).
+ */
+export function AchievementsHeader({
+  earnedCount,
+  totalCount,
+}: {
+  earnedCount: number;
+  totalCount: number;
+}) {
+  const { t } = useLanguage();
+  const percent = totalCount > 0 ? (earnedCount / totalCount) * 100 : 0;
+
+  return (
+    <View className="overflow-hidden rounded-2xl border border-f1-white/10 bg-f1-white/5">
+      <View className="flex-row items-center gap-3 border-b border-f1-white/10 px-5 py-4">
+        <View className="h-9 w-9 items-center justify-center rounded-xl bg-f1-purple/10">
+          <Ionicons name="ribbon" size={18} color="#A06CD5" />
+        </View>
+        <View>
+          <Text className="text-sm font-semibold text-f1-white">{t.achievementsPage.title}</Text>
+          <Text className="text-[11px] text-f1-white/50">
+            {earnedCount} {t.achievementsPage.of} {totalCount} {t.achievementsPage.unlocked}
+          </Text>
+        </View>
+      </View>
+
+      <View className="px-5 py-3">
+        <View
+          className="h-1.5 w-full overflow-hidden rounded-full bg-f1-white/10"
+          accessibilityRole="progressbar"
+          accessibilityLabel={`${earnedCount} ${t.achievementsPage.of} ${totalCount} ${t.achievementsPage.unlocked}`}
+          accessibilityValue={{ min: 0, max: totalCount, now: earnedCount }}
+        >
+          <View className="h-full rounded-full bg-f1-purple" style={{ width: `${percent}%` }} />
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/achievements/CategoryChips.tsx
+++ b/apps/mobile/src/components/achievements/CategoryChips.tsx
@@ -1,0 +1,73 @@
+import { Pressable, ScrollView, Text } from "react-native";
+
+import type { AchievementCategory } from "@f1/shared/types";
+
+export type CategoryFilter = AchievementCategory | "all";
+
+interface ChipItem {
+  value: CategoryFilter;
+  label: string;
+  count: number;
+}
+
+function Chip({
+  item,
+  active,
+  onSelect,
+}: {
+  item: ChipItem;
+  active: boolean;
+  onSelect: (value: CategoryFilter) => void;
+}) {
+  return (
+    <Pressable
+      onPress={() => onSelect(item.value)}
+      accessibilityRole="button"
+      accessibilityLabel={`${item.label} (${item.count})`}
+      accessibilityState={{ selected: active }}
+      className={`min-h-9 flex-row items-center gap-1.5 rounded-lg border px-3 py-1.5 ${
+        active ? "border-f1-purple/40 bg-f1-white/5" : "border-f1-white/10 active:bg-f1-white/10"
+      }`}
+    >
+      <Text
+        className={`text-[11px] font-medium ${active ? "text-f1-purple" : "text-f1-white/50"}`}
+      >
+        {item.label}
+      </Text>
+      <Text
+        className={`rounded-md px-1 py-0.5 text-[9px] tabular-nums ${
+          active ? "bg-f1-purple/20 text-f1-purple" : "bg-f1-white/10 text-f1-white/50"
+        }`}
+      >
+        {item.count}
+      </Text>
+    </Pressable>
+  );
+}
+
+/**
+ * Horizontally scrollable category filter chips (All / Predictions /
+ * Accuracy / Milestones / Special), each with a count badge. Ports the web
+ * FilterButton row.
+ */
+export function CategoryChips({
+  items,
+  active,
+  onSelect,
+}: {
+  items: ChipItem[];
+  active: CategoryFilter;
+  onSelect: (value: CategoryFilter) => void;
+}) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerClassName="flex-row gap-2"
+    >
+      {items.map((item) => (
+        <Chip key={item.value} item={item} active={active === item.value} onSelect={onSelect} />
+      ))}
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/lib/achievement-icons.ts
+++ b/apps/mobile/src/lib/achievement-icons.ts
@@ -1,0 +1,55 @@
+import type { Ionicons } from "@expo/vector-icons";
+
+export type IoniconName = keyof typeof Ionicons.glyphMap;
+
+/**
+ * Mobile counterpart of the web's lucide icon map
+ * (apps/web/lib/achievements.ts ACHIEVEMENT_ICONS). Maps the same 33
+ * achievement slugs to semantically close Ionicons names, since lucide-react
+ * renders DOM and cannot be used in React Native.
+ */
+export const ACHIEVEMENT_ICON_NAMES: Record<string, IoniconName> = {
+  // Predictions
+  first_prediction: "flag", // web: Flag
+  "10_predictions": "clipboard", // web: ClipboardList
+  "20_predictions": "bookmark", // web: BookMarked
+  all_2026_predictions: "calendar-number", // web: CalendarCheck
+  // Accuracy
+  "1_correct": "locate", // web: Target
+  "10_correct": "scan", // web: Crosshair
+  "50_correct": "eye", // web: Eye
+  "100_correct": "telescope", // web: Telescope
+  predict_race_winner: "trophy", // web: Trophy
+  predict_pole: "medal", // web: Medal
+  predict_fastest_lap: "flash", // web: Zap
+  predict_fastest_pit: "build", // web: Wrench
+  fans_choice: "heart", // web: Heart
+  sprint_winner: "speedometer", // web: Gauge
+  sprint_pole: "timer", // web: Timer
+  sprint_fastest_lap: "rocket", // web: Rocket
+  // Milestones
+  "100_points": "star", // web: Star
+  "200_points": "diamond", // web: Gem
+  "300_points": "sparkles", // web: Sparkles
+  race_prediction_winner_10: "shield", // web: Shield
+  predict_5_team_best: "people", // web: Users
+  predict_10_team_best: "git-network", // web: Network
+  // Special
+  perfect_podium: "ribbon", // web: Award
+  perfect_top_10: "layers", // web: Layers
+  sprint_podium: "trending-up", // web: TrendingUp
+  perfect_top_8: "grid", // web: LayoutGrid
+  hat_trick: "color-wand", // web: Wand2
+  predict_wdc: "planet", // web: Crown (Ionicons has no crown; world champion → planet)
+  predict_wcc: "balloon", // web: PartyPopper
+  race_prediction_winner: "podium", // web: Swords (no swords in Ionicons)
+  race_prediction_podium: "hammer", // web: Anvil
+  sprint_prediction_winner: "flame", // web: Flame
+  sprint_prediction_podium: "checkmark-circle", // web: BadgeCheck
+  predict_1_team_best: "car-sport", // web: Car
+};
+
+/** Ionicons name for an achievement slug; falls back to the trophy. */
+export function getAchievementIconName(slug: string): IoniconName {
+  return ACHIEVEMENT_ICON_NAMES[slug] ?? "trophy";
+}

--- a/apps/mobile/src/lib/achievement-styles.ts
+++ b/apps/mobile/src/lib/achievement-styles.ts
@@ -1,0 +1,35 @@
+import type { AchievementCategory } from "@f1/shared/types";
+
+export interface CategoryStyle {
+  /** NativeWind class for tinted icon/badge backgrounds. */
+  bgClass: string;
+  /** NativeWind class for tinted text. */
+  textClass: string;
+  /** Hex color for Ionicons `color` props (icons can't take classes). */
+  hex: string;
+}
+
+/**
+ * Mobile counterpart of the shared CATEGORY_COLORS
+ * (@f1/shared/lib/achievements). The shared map holds Tailwind class strings,
+ * but NativeWind only compiles classes it finds inside apps/mobile/src (see
+ * tailwind.config.js `content`), so the literals must live here. Same f1-*
+ * palette mapping as the web: predictions=blue, accuracy=green,
+ * milestones=amber, special=purple.
+ */
+export const CATEGORY_STYLES: Record<AchievementCategory, CategoryStyle> = {
+  predictions: { bgClass: "bg-f1-blue/10", textClass: "text-f1-blue", hex: "#3C91E6" },
+  accuracy: { bgClass: "bg-f1-green/10", textClass: "text-f1-green", hex: "#44AF69" },
+  milestones: { bgClass: "bg-f1-amber/10", textClass: "text-f1-amber", hex: "#FFB100" },
+  special: { bgClass: "bg-f1-purple/10", textClass: "text-f1-purple", hex: "#A06CD5" },
+};
+
+const CATEGORY_STYLE_FALLBACK: CategoryStyle = {
+  bgClass: "bg-f1-white/10",
+  textClass: "text-f1-white/50",
+  hex: "#F7F7F780",
+};
+
+export function getCategoryStyle(category: string): CategoryStyle {
+  return CATEGORY_STYLES[category as AchievementCategory] ?? CATEGORY_STYLE_FALLBACK;
+}

--- a/apps/web/__tests__/lib/achievement-calculator.test.ts
+++ b/apps/web/__tests__/lib/achievement-calculator.test.ts
@@ -1,14 +1,18 @@
 /**
  * Tests for lib/achievement-calculator.ts — service layer with mocked Supabase.
  *
- * Covers: calculateAchievementsForUsers, calculateAchievementsForAllUsers
+ * Covers: calculateAchievementsForUsers, calculateAchievementsForAllUsers,
+ * fetchUserProgressData, buildProgressMap (pure)
  */
 import { createMockSupabase } from "../helpers/mockSupabase";
 import {
   calculateAchievementsForUsers,
   calculateAchievementsForAllUsers,
   fetchUserProgressData,
+  buildProgressMap,
+  type UserProgressCounts,
 } from "@f1/shared/lib/achievement-calculator";
+import type { Achievement } from "@f1/shared/types";
 
 /* ── Helpers ─────────────────────────────────────────────────────────── */
 
@@ -1590,5 +1594,213 @@ describe("fetchUserProgressData", () => {
     expect(counts.totalSeasonRounds).toBe(3);
     // completedSeasonRounds: race5 race pred ✓ + race5 sprint pred ✓ = 2; race6 = 0
     expect(counts.completedSeasonRounds).toBe(2);
+  });
+});
+
+/* ── buildProgressMap (pure function — no mocks) ─────────────────────── */
+
+describe("buildProgressMap", () => {
+  /** Achievement fixture factory with sensible defaults. */
+  function makeAchievement(
+    id: number,
+    slug: string,
+    threshold: number | null
+  ): Achievement {
+    return {
+      id,
+      slug,
+      name: slug,
+      description: "",
+      iconUrl: null,
+      category: "predictions",
+      threshold,
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+  }
+
+  /** Progress fixture with distinct values per counter so wrong wiring fails. */
+  function makeProgress(
+    overrides: Partial<UserProgressCounts> = {}
+  ): UserProgressCounts {
+    return {
+      totalPredictions: 7,
+      totalCorrectPredictions: 13,
+      totalPoints: 150,
+      raceFirstCount: 2,
+      raceTop3Count: 4,
+      sprintFirstCount: 1,
+      sprintTop3Count: 3,
+      tbdCorrectCount: 6,
+      completedSeasonRounds: 5,
+      totalSeasonRounds: 29,
+      ...overrides,
+    };
+  }
+
+  it("returns an empty map for an empty achievements list", () => {
+    expect(buildProgressMap([], makeProgress())).toEqual({});
+  });
+
+  it("maps prediction-count slugs to totalPredictions with threshold as max", () => {
+    const achievements = [
+      makeAchievement(1, "first_prediction", 1),
+      makeAchievement(2, "10_predictions", 10),
+      makeAchievement(3, "20_predictions", 20),
+    ];
+    const map = buildProgressMap(achievements, makeProgress());
+    expect(map[1]).toEqual({ current: 7, max: 1 });
+    expect(map[2]).toEqual({ current: 7, max: 10 });
+    expect(map[3]).toEqual({ current: 7, max: 20 });
+  });
+
+  it("maps all_2026_predictions to season-round counts instead of its threshold", () => {
+    const map = buildProgressMap(
+      [makeAchievement(4, "all_2026_predictions", null)],
+      makeProgress({ completedSeasonRounds: 12, totalSeasonRounds: 29 })
+    );
+    expect(map[4]).toEqual({ current: 12, max: 29 });
+  });
+
+  it("maps correct-prediction slugs to totalCorrectPredictions", () => {
+    const achievements = [
+      makeAchievement(5, "1_correct", 1),
+      makeAchievement(6, "10_correct", 10),
+      makeAchievement(7, "50_correct", 50),
+      makeAchievement(8, "100_correct", 100),
+    ];
+    const map = buildProgressMap(achievements, makeProgress());
+    expect(map[5]).toEqual({ current: 13, max: 1 });
+    expect(map[6]).toEqual({ current: 13, max: 10 });
+    expect(map[7]).toEqual({ current: 13, max: 50 });
+    expect(map[8]).toEqual({ current: 13, max: 100 });
+  });
+
+  it("maps points-milestone slugs to totalPoints", () => {
+    const achievements = [
+      makeAchievement(9, "100_points", 100),
+      makeAchievement(10, "200_points", 200),
+      makeAchievement(11, "300_points", 300),
+    ];
+    const map = buildProgressMap(achievements, makeProgress());
+    expect(map[9]).toEqual({ current: 150, max: 100 });
+    expect(map[10]).toEqual({ current: 150, max: 200 });
+    expect(map[11]).toEqual({ current: 150, max: 300 });
+  });
+
+  it("maps race leaderboard winner slugs to raceFirstCount", () => {
+    const achievements = [
+      makeAchievement(12, "race_prediction_winner", 1),
+      makeAchievement(13, "race_prediction_winner_10", 10),
+    ];
+    const map = buildProgressMap(achievements, makeProgress());
+    expect(map[12]).toEqual({ current: 2, max: 1 });
+    expect(map[13]).toEqual({ current: 2, max: 10 });
+  });
+
+  it("maps podium and sprint leaderboard slugs to their own counters", () => {
+    const achievements = [
+      makeAchievement(14, "race_prediction_podium", 1),
+      makeAchievement(15, "sprint_prediction_winner", 1),
+      makeAchievement(16, "sprint_prediction_podium", 1),
+    ];
+    const map = buildProgressMap(achievements, makeProgress());
+    expect(map[14]).toEqual({ current: 4, max: 1 }); // raceTop3Count
+    expect(map[15]).toEqual({ current: 1, max: 1 }); // sprintFirstCount
+    expect(map[16]).toEqual({ current: 3, max: 1 }); // sprintTop3Count
+  });
+
+  it("maps team-best slugs to tbdCorrectCount", () => {
+    const achievements = [
+      makeAchievement(17, "predict_1_team_best", 1),
+      makeAchievement(18, "predict_5_team_best", 5),
+      makeAchievement(19, "predict_10_team_best", 10),
+    ];
+    const map = buildProgressMap(achievements, makeProgress());
+    expect(map[17]).toEqual({ current: 6, max: 1 });
+    expect(map[18]).toEqual({ current: 6, max: 5 });
+    expect(map[19]).toEqual({ current: 6, max: 10 });
+  });
+
+  it("gives binary achievements without a threshold a 0/1 locked entry", () => {
+    const achievements = [
+      makeAchievement(20, "hat_trick", null),
+      makeAchievement(21, "predict_wdc", null),
+      makeAchievement(22, "perfect_podium", null),
+    ];
+    const map = buildProgressMap(achievements, makeProgress());
+    expect(map[20]).toEqual({ current: 0, max: 1 });
+    expect(map[21]).toEqual({ current: 0, max: 1 });
+    expect(map[22]).toEqual({ current: 0, max: 1 });
+  });
+
+  it("excludes unknown slugs that carry a threshold", () => {
+    // current stays undefined but threshold != null → neither branch matches
+    const map = buildProgressMap(
+      [makeAchievement(23, "some_future_achievement", 5)],
+      makeProgress()
+    );
+    expect(map[23]).toBeUndefined();
+    expect(map).toEqual({});
+  });
+
+  it("excludes progress-family achievements whose threshold is null", () => {
+    // e.g. misconfigured row: counted slug but no threshold → max undefined
+    const map = buildProgressMap(
+      [
+        makeAchievement(24, "10_predictions", null),
+        makeAchievement(25, "100_points", null),
+      ],
+      makeProgress()
+    );
+    expect(map).toEqual({});
+  });
+
+  it("excludes entries whose max is zero or negative", () => {
+    const achievements = [
+      makeAchievement(26, "10_predictions", 0),
+      makeAchievement(27, "100_points", -5),
+      makeAchievement(28, "all_2026_predictions", null),
+    ];
+    const map = buildProgressMap(
+      achievements,
+      makeProgress({ completedSeasonRounds: 0, totalSeasonRounds: 0 })
+    );
+    // threshold 0 and -5 → max <= 0; season with 0 rounds → max 0
+    expect(map).toEqual({});
+  });
+
+  it("keeps a zero current when max is positive", () => {
+    const map = buildProgressMap(
+      [makeAchievement(29, "1_correct", 1)],
+      makeProgress({ totalCorrectPredictions: 0 })
+    );
+    expect(map[29]).toEqual({ current: 0, max: 1 });
+  });
+
+  it("does not cap current at max (caller clamps for display)", () => {
+    const map = buildProgressMap(
+      [makeAchievement(30, "100_points", 100)],
+      makeProgress({ totalPoints: 450 })
+    );
+    expect(map[30]).toEqual({ current: 450, max: 100 });
+  });
+
+  it("builds a combined map across all families in one pass", () => {
+    const achievements = [
+      makeAchievement(1, "first_prediction", 1),
+      makeAchievement(2, "all_2026_predictions", null),
+      makeAchievement(3, "50_correct", 50),
+      makeAchievement(4, "200_points", 200),
+      makeAchievement(5, "race_prediction_winner", 1),
+      makeAchievement(6, "predict_5_team_best", 5),
+      makeAchievement(7, "hat_trick", null), // binary
+      makeAchievement(8, "mystery_slug", 3), // unknown + threshold → excluded
+    ];
+    const map = buildProgressMap(achievements, makeProgress());
+    expect(Object.keys(map).map(Number).sort((a, b) => a - b)).toEqual([
+      1, 2, 3, 4, 5, 6, 7,
+    ]);
+    expect(map[2]).toEqual({ current: 5, max: 29 });
+    expect(map[7]).toEqual({ current: 0, max: 1 });
   });
 });

--- a/apps/web/app/achievements/page.tsx
+++ b/apps/web/app/achievements/page.tsx
@@ -5,80 +5,10 @@ import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import { AchievementsContent } from "@/components/achievements/AchievementsContent";
 import { fetchAchievementsData } from "@/lib/achievements";
-import { fetchUserProgressData } from "@f1/shared/lib/achievement-calculator";
-import type { Achievement } from "@f1/shared/types";
-import type { UserProgressCounts } from "@f1/shared/lib/achievement-calculator";
-
-function buildProgressMap(
-  achievements: Achievement[],
-  progress: UserProgressCounts
-): Record<number, { current: number; max: number }> {
-  const map: Record<number, { current: number; max: number }> = {};
-
-  for (const ach of achievements) {
-    const threshold = ach.threshold;
-    let current: number | undefined;
-    let max: number | undefined;
-
-    switch (ach.slug) {
-      case "first_prediction":
-      case "10_predictions":
-      case "20_predictions":
-        current = progress.totalPredictions;
-        max = threshold ?? undefined;
-        break;
-      case "all_2026_predictions":
-        current = progress.completedSeasonRounds;
-        max = progress.totalSeasonRounds;
-        break;
-      case "1_correct":
-      case "10_correct":
-      case "50_correct":
-      case "100_correct":
-        current = progress.totalCorrectPredictions;
-        max = threshold ?? undefined;
-        break;
-      case "100_points":
-      case "200_points":
-      case "300_points":
-        current = progress.totalPoints;
-        max = threshold ?? undefined;
-        break;
-      case "race_prediction_winner":
-      case "race_prediction_winner_10":
-        current = progress.raceFirstCount;
-        max = threshold ?? undefined;
-        break;
-      case "race_prediction_podium":
-        current = progress.raceTop3Count;
-        max = threshold ?? undefined;
-        break;
-      case "sprint_prediction_winner":
-        current = progress.sprintFirstCount;
-        max = threshold ?? undefined;
-        break;
-      case "sprint_prediction_podium":
-        current = progress.sprintTop3Count;
-        max = threshold ?? undefined;
-        break;
-      case "predict_1_team_best":
-      case "predict_5_team_best":
-      case "predict_10_team_best":
-        current = progress.tbdCorrectCount;
-        max = threshold ?? undefined;
-        break;
-    }
-
-    if (current !== undefined && max !== undefined && max > 0) {
-      map[ach.id] = { current, max };
-    } else if (current === undefined && ach.threshold == null) {
-      // Binary achievement (no threshold, boolean condition) — show 0 / 1 when locked
-      map[ach.id] = { current: 0, max: 1 };
-    }
-  }
-
-  return map;
-}
+import {
+  buildProgressMap,
+  fetchUserProgressData,
+} from "@f1/shared/lib/achievement-calculator";
 
 export default async function AchievementsPage() {
   const supabase = await createClient();

--- a/docs/mobile-migration/decisions.md
+++ b/docs/mobile-migration/decisions.md
@@ -2,6 +2,34 @@
 
 Running record of decisions made after the initial plan. Newest first.
 
+## 2026-07-12 — Achievements screen as a 5th tab; Phase 4c reshaped around a header avatar (Phase 4b)
+
+**Navigation decision:** the bottom bar grows to **five tabs** — Home / Predictions / Leaderboard /
+Standings / **Achievements** (Ionicons `ribbon`; `trophy` was taken by Standings). Profile does
+**not** become a 6th tab: Phase 4c will instead put an **avatar button in the top bar** opening a
+profile/settings surface (display name, language toggle, sign out, password change, account
+deletion). A theme toggle was floated but both apps are dark-only today, so it's v2 polish, not
+4c parity scope.
+
+**Screen:** ports the web `AchievementsContent` — header card with overall progress bar, category
+filter chips (All + 4 categories with count badges, horizontal scroll), earned vs locked cards,
+category badge pills, and per-achievement progress bars on locked cards. The web grid's "Still
+cooking" placeholder cell is not ported (consistent with 4a's banner/placeholder decision). The
+achievements query reuses the Home screen's `["achievements", userId]` key so the cache is shared.
+
+**Shared extraction:** `buildProgressMap(achievements, progress)` (+`AchievementProgressMap`)
+moved verbatim from `apps/web/app/achievements/page.tsx` into
+`packages/shared/lib/achievement-calculator.ts` next to `fetchUserProgressData`; the web page now
+imports it. Covered by unit tests (100% on the function), which also pin two quirks: a known slug
+with a null/zero threshold silently gets no progress entry, and `current` is not clamped to `max`
+(both UIs clamp at render).
+
+**Mobile-only mappings:** the lucide icon map stays web-only per the plan; mobile adds
+`achievement-icons.ts` (33 slugs → Ionicons, trophy fallback, typed against `Ionicons.glyphMap`)
+and `achievement-styles.ts` (category → f1-palette classes + hex, because shared `CATEGORY_COLORS`
+Tailwind strings aren't scanned by the mobile NativeWind config). Category labels use four new
+`achievementsPage.category*` keys in both locales; web keeps its `CATEGORY_LABELS` untouched.
+
 ## 2026-07-12 — Home dashboard screen (Phase 4a)
 
 **Decision:** The mobile Home tab replaces the Phase-1 smoke screen with the real dashboard as a

--- a/docs/mobile-migration/mobile-migration-plan.md
+++ b/docs/mobile-migration/mobile-migration-plan.md
@@ -9,9 +9,9 @@
 > | 1 — Mobile scaffold | ✅ Done (PR #82, 2026-07-08 — Expo SDK 54) |
 > | 2 — Auth | ✅ Done (PR #84, 2026-07-10 — email/password + Google; **Apple sign-in deferred**, see decisions.md) |
 > | 3 — Core loop | ✅ Done (verified in Expo Go on-device, 2026-07-12). Race prediction screen (PR #85, 2026-07-11 — incl. Bearer-token API auth). Leaderboard + standings screens (PR #86, 2026-07-11 — incl. bottom tab navigator + shared `fetchDetailedLeaderboard` extraction). Sprint + champion tabs and the results-comparison display (PR #87, 2026-07-11 — incl. shared sprint/champion/results fetcher extractions, see decisions.md) |
-> | 4a — Home dashboard screen | ✅ Code complete (2026-07-12 — incl. shared `fetchDashboardData` extraction, bottom-sheet point system + race calendar, see decisions.md). **Next:** verify in Expo Go on-device, then Phase 4b |
-> | 4b — Achievements screen | ⬜ Not started |
-> | 4c — Profile & account settings | ⬜ Not started |
+> | 4a — Home dashboard screen | ✅ Done (PR #88, 2026-07-12 — incl. shared `fetchDashboardData` extraction, bottom-sheet point system + race calendar, see decisions.md) |
+> | 4b — Achievements screen | ✅ Code complete (2026-07-12 — 5th bottom tab, shared `buildProgressMap` extraction, Ionicons icon map, see decisions.md). **Next:** verify in Expo Go on-device, then Phase 4c |
+> | 4c — Profile & account settings | ⬜ Not started (**reshaped:** avatar in the top bar opening a profile/settings surface — language, sign out, account flows — instead of a 6th tab, see decisions.md 2026-07-12) |
 > | 5 — Ship (EAS Submit) | ⬜ Not started |
 > **Stack:** React Native + Expo (developer is on Windows, learning RN/Expo via a course
 > that covers Expo Router, NativeWind, TanStack Query, EAS Build + Publish).

--- a/packages/shared/lib/achievement-calculator.ts
+++ b/packages/shared/lib/achievement-calculator.ts
@@ -14,6 +14,7 @@ import {
 } from "./scoring";
 
 import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Achievement } from "../types";
 
 /**
  * Resolve the authoritative qualifying top-3 array for a prediction or result
@@ -826,4 +827,86 @@ export async function fetchUserProgressData(
     completedSeasonRounds,
     totalSeasonRounds,
   };
+}
+
+/** Per-achievement progress entries keyed by achievement id. */
+export type AchievementProgressMap = Record<
+  number,
+  { current: number; max: number }
+>;
+
+/**
+ * Builds the progress map shown on the achievements page: for each
+ * achievement, the user's current count and the target needed to unlock it.
+ * Pure function — no I/O.
+ */
+export function buildProgressMap(
+  achievements: Achievement[],
+  progress: UserProgressCounts
+): AchievementProgressMap {
+  const map: AchievementProgressMap = {};
+
+  for (const ach of achievements) {
+    const threshold = ach.threshold;
+    let current: number | undefined;
+    let max: number | undefined;
+
+    switch (ach.slug) {
+      case "first_prediction":
+      case "10_predictions":
+      case "20_predictions":
+        current = progress.totalPredictions;
+        max = threshold ?? undefined;
+        break;
+      case "all_2026_predictions":
+        current = progress.completedSeasonRounds;
+        max = progress.totalSeasonRounds;
+        break;
+      case "1_correct":
+      case "10_correct":
+      case "50_correct":
+      case "100_correct":
+        current = progress.totalCorrectPredictions;
+        max = threshold ?? undefined;
+        break;
+      case "100_points":
+      case "200_points":
+      case "300_points":
+        current = progress.totalPoints;
+        max = threshold ?? undefined;
+        break;
+      case "race_prediction_winner":
+      case "race_prediction_winner_10":
+        current = progress.raceFirstCount;
+        max = threshold ?? undefined;
+        break;
+      case "race_prediction_podium":
+        current = progress.raceTop3Count;
+        max = threshold ?? undefined;
+        break;
+      case "sprint_prediction_winner":
+        current = progress.sprintFirstCount;
+        max = threshold ?? undefined;
+        break;
+      case "sprint_prediction_podium":
+        current = progress.sprintTop3Count;
+        max = threshold ?? undefined;
+        break;
+      case "predict_1_team_best":
+      case "predict_5_team_best":
+      case "predict_10_team_best":
+        current = progress.tbdCorrectCount;
+        max = threshold ?? undefined;
+        break;
+    }
+
+    if (current !== undefined && max !== undefined && max > 0) {
+      map[ach.id] = { current, max };
+    } else if (current === undefined && ach.threshold == null) {
+      // Binary achievement (no threshold, boolean condition) — show 0 / 1 when locked
+      map[ach.id] = { current: 0, max: 1 };
+    }
+  }
+
+  return map;
 }

--- a/packages/shared/messages/en.ts
+++ b/packages/shared/messages/en.ts
@@ -381,6 +381,10 @@ const en = {
     of: "of",
     all: "All",
     noAchievements: "No achievements in this category",
+    categoryPredictions: "Predictions",
+    categoryAccuracy: "Accuracy",
+    categoryMilestones: "Milestones",
+    categorySpecial: "Special",
   },
 
   // ── Profile page ────────────────────────────────────────────────────────

--- a/packages/shared/messages/es.ts
+++ b/packages/shared/messages/es.ts
@@ -374,6 +374,10 @@ const es: Messages = {
     of: "de",
     all: "Todos",
     noAchievements: "No hay logros en esta categoría",
+    categoryPredictions: "Predicciones",
+    categoryAccuracy: "Precisión",
+    categoryMilestones: "Hitos",
+    categorySpecial: "Especiales",
   },
 
   // ── Profile page ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Phase 4b of the mobile migration: the Achievements screen joins the mobile app as a 5th bottom tab, following the established shared-extraction pattern.

### Navigation decision
- Bottom bar grows to five tabs: Home / Predictions / Leaderboard / Standings / **Achievements** (Ionicons `ribbon`).
- Phase 4c is reshaped: instead of a 6th Profile tab, an avatar in the top bar will open the profile/settings surface (recorded in decisions.md).

### Shared extraction (`packages/shared/lib/achievement-calculator.ts`)
- `buildProgressMap(achievements, progress)` + `AchievementProgressMap` moved verbatim from `apps/web/app/achievements/page.tsx`; the web page now imports it. Web behavior unchanged.

### Mobile Achievements screen (`apps/mobile`)
- Header card with overall unlocked-progress bar; category filter chips (All + 4 categories with count badges); earned vs locked cards with category pills and per-achievement progress bars on locked cards; empty-category state. "Still cooking" placeholder cell intentionally not ported.
- Reuses the Home screen's `["achievements", userId]` query key (shared cache) + a new progress query.
- Mobile-only mappings: `achievement-icons.ts` (33 slugs → Ionicons, typed against the glyph map, trophy fallback) and `achievement-styles.ts` (category → f1 palette classes + hex).
- 4 new `achievementsPage.category*` translation keys in both locales (en/es parity 486/486); web keeps its hardcoded `CATEGORY_LABELS`.

### Tests & gates
- 14 new unit tests for `buildProgressMap` (100% coverage on the function; suite now 444 passing). Tests pin two quirks: null/zero-threshold slugs get no progress entry, and `current` isn't clamped (both UIs clamp at render).
- `tsc --noEmit` clean (web + mobile), lint 0 errors, translation parity intact.

### Docs
- Migration plan: 4a marked done (PR #88), 4b code complete (pending Expo Go verification), 4c reshaped.
- New decision-log entry for the 4b design and navigation choices.