### PR TITLE
chore: add .gitattributes to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Normalize line endings to LF in the repo so diffs stay clean across machines
+# and Windows checkouts stop emitting "LF will be replaced by CRLF" warnings.
+# Files are already stored with LF, so this is a no-op renormalization.
+* text=auto eol=lf
+
+# Binary assets — never run text/EOL conversion on these.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.webp binary
+*.svg  text
+*.ttf  binary
+*.otf  binary
+*.woff binary
+*.woff2 binary


### PR DESCRIPTION
Adds a `.gitattributes` that normalizes text files to **LF** and marks common image/font types as binary.

## Why
Windows checkouts (with `core.autocrlf=true`) emit `LF will be replaced by CRLF` warnings on every commit. The repo already stores files with LF, so pinning `* text=auto eol=lf` silences the warnings and keeps diffs consistent across machines.

## Notes
- **No renormalization churn** — only `.gitattributes` is added; existing files are already LF, so nothing else changes.
- Image/font extensions (`*.png`, `*.woff2`, …) are marked `binary` so they're never run through EOL conversion; `*.svg` stays `text`.