### PR TITLE
feat(web): keep-alive cron to prevent Supabase free-tier pausing

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,3 +4,9 @@
 # under Settings -> API.
 NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+
+# Optional. A random secret shared with Vercel Cron so the keep-alive endpoint
+# (/api/cron/keep-alive) can't be triggered by the public. Set the same value
+# in the Vercel project's Environment Variables; Vercel then sends it as an
+# Authorization: Bearer header on scheduled runs. Not needed for local dev.
+CRON_SECRET=

--- a/apps/web/app/api/cron/keep-alive/route.ts
+++ b/apps/web/app/api/cron/keep-alive/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * Keep-alive cron. Supabase pauses free-tier projects after ~7 days of
+ * inactivity; this endpoint issues a trivial database read so the project
+ * always looks active. It's triggered daily by Vercel Cron (see
+ * apps/web/vercel.json) — an *external* ping is required because a paused
+ * project's own pg_cron is suspended and can't self-wake.
+ *
+ * Least privilege on purpose: it uses the public anon key and a single
+ * `select ... limit 1` against a publicly-readable table. The goal is only to
+ * register activity, never to read anything meaningful.
+ */
+
+// Never cache/statically optimize — the handler must actually run each call.
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  // When CRON_SECRET is set, Vercel Cron sends it as `Authorization: Bearer …`.
+  // Reject anything else so the route isn't a public database-poke. If the
+  // secret is unset the check is skipped (still functional, just unauthenticated).
+  const secret = process.env.CRON_SECRET;
+  if (secret && request.headers.get("authorization") !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { persistSession: false } }
+  );
+
+  const { error } = await supabase.from("races").select("id").limit(1);
+
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, pingedAt: new Date().toISOString() });
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/keep-alive",
+      "schedule": "0 6 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Keeps the free-tier Supabase project from pausing (~7 days of inactivity) so the app stays alive for friends during quiet periods.

## How it works
- **`apps/web/vercel.json`** — a Vercel Cron that calls `/api/cron/keep-alive` daily at 06:00 UTC. Daily gives a 7× margin over the pause window and stays within Hobby's once-per-day cron limit.
- **`apps/web/app/api/cron/keep-alive/route.ts`** — issues a trivial `select id from races limit 1` with the **anon** key (least privilege; only registers DB activity). Guarded by `CRON_SECRET`: when that env var is set, only requests carrying `Authorization: Bearer <CRON_SECRET>` are accepted (Vercel Cron adds this header automatically).

## Why Vercel Cron (not GitHub Actions)
GitHub's scheduled workflows are **auto-disabled after 60 days of no repo commits** — which is exactly when a hobby project goes quiet and most needs the ping. Vercel Cron runs as long as the app is *deployed*, independent of commit activity. `pg_cron` inside Supabase can't do it either: a paused project's cron is suspended, so the wake-up must come from outside.

## ⚠️ Manual steps after merge
1. **Set `CRON_SECRET`** in the Vercel project → Settings → Environment Variables (Production): any long random string. Without it the endpoint still works but is publicly triggerable (low risk — it only does a trivial read).
2. **Verify the cron registered:** after the next production deploy, check Vercel → the project → **Cron Jobs**; `/api/cron/keep-alive` should be listed.
3. **Root Directory assumption:** this places `vercel.json` in `apps/web/`, assuming the Vercel project's **Root Directory** is set to `apps/web` (standard for this monorepo). If it's actually the repo root, move `vercel.json` to the root instead.

## Verify it's working
Hit `https://<your-app>/api/cron/keep-alive` in a browser (works when `CRON_SECRET` is unset) — expect `{ "ok": true, "pingedAt": "…" }`. Or watch the run logs under Vercel → Cron Jobs after the first scheduled execution.